### PR TITLE
hotfix: entities 재생성 및 synchronize false

### DIFF
--- a/src/_entities/FeedCategoryMapping.ts
+++ b/src/_entities/FeedCategoryMapping.ts
@@ -1,14 +1,8 @@
-import {
-  Column,
-  Entity,
-  Index,
-  JoinColumn,
-  ManyToOne,
-  OneToOne,
-} from "typeorm";
-import { Feeds } from "./Feeds";
+import { Column, Entity, Index, JoinColumn, ManyToOne } from "typeorm";
 import { Categories } from "./Categories";
+import { Feeds } from "./Feeds";
 
+@Index("FK_FeedCategoryMapping_feedId_Feeds_feedId", ["feedId"], {})
 @Index(
   "FK_FeedCategoryMapping_categoryId_Categories_categoryId",
   ["categoryId"],
@@ -16,18 +10,14 @@ import { Categories } from "./Categories";
 )
 @Entity("FeedCategoryMapping", { schema: "devDB" })
 export class FeedCategoryMapping {
-  @Column("int", { primary: true, name: "feedId", unsigned: true })
+  @Column("int", { name: "feedId", unsigned: true })
   feedId: number;
 
   @Column("int", { name: "categoryId", unsigned: true })
   categoryId: number;
 
-  @OneToOne(() => Feeds, (feeds) => feeds.feedCategoryMapping, {
-    onDelete: "RESTRICT",
-    onUpdate: "RESTRICT",
-  })
-  @JoinColumn([{ name: "feedId", referencedColumnName: "feedId" }])
-  feed: Feeds;
+  @Column("int", { primary: true, name: "id", unsigned: true })
+  id: number;
 
   @ManyToOne(
     () => Categories,
@@ -36,4 +26,11 @@ export class FeedCategoryMapping {
   )
   @JoinColumn([{ name: "categoryId", referencedColumnName: "categoryId" }])
   category: Categories;
+
+  @ManyToOne(() => Feeds, (feeds) => feeds.feedCategoryMappings, {
+    onDelete: "RESTRICT",
+    onUpdate: "RESTRICT",
+  })
+  @JoinColumn([{ name: "feedId", referencedColumnName: "feedId" }])
+  feed: Feeds;
 }

--- a/src/_entities/FeedHashTagMapping.ts
+++ b/src/_entities/FeedHashTagMapping.ts
@@ -1,22 +1,26 @@
-import {
-  Column,
-  Entity,
-  Index,
-  JoinColumn,
-  ManyToOne,
-  OneToOne,
-} from "typeorm";
-import { HashTags } from "./HashTags";
+import { Column, Entity, Index, JoinColumn, ManyToOne } from "typeorm";
 import { Feeds } from "./Feeds";
+import { HashTags } from "./HashTags";
 
 @Index("FK_FeedHashTagMapping_hashTagId_HashTags_hashTagId", ["hashTagId"], {})
+@Index("FK_FeedHashTagMapping_feedId_Feeds_feedId", ["feedId"], {})
 @Entity("FeedHashTagMapping", { schema: "devDB" })
 export class FeedHashTagMapping {
-  @Column("int", { primary: true, name: "feedId", unsigned: true })
+  @Column("int", { name: "feedId", unsigned: true })
   feedId: number;
 
   @Column("int", { name: "hashTagId", unsigned: true })
   hashTagId: number;
+
+  @Column("int", { primary: true, name: "id", unsigned: true })
+  id: number;
+
+  @ManyToOne(() => Feeds, (feeds) => feeds.feedHashTagMappings, {
+    onDelete: "RESTRICT",
+    onUpdate: "RESTRICT",
+  })
+  @JoinColumn([{ name: "feedId", referencedColumnName: "feedId" }])
+  feed: Feeds;
 
   @ManyToOne(() => HashTags, (hashTags) => hashTags.feedHashTagMappings, {
     onDelete: "RESTRICT",
@@ -24,11 +28,4 @@ export class FeedHashTagMapping {
   })
   @JoinColumn([{ name: "hashTagId", referencedColumnName: "hashTagId" }])
   hashTag: HashTags;
-
-  @OneToOne(() => Feeds, (feeds) => feeds.feedHashTagMapping, {
-    onDelete: "RESTRICT",
-    onUpdate: "RESTRICT",
-  })
-  @JoinColumn([{ name: "feedId", referencedColumnName: "feedId" }])
-  feed: Feeds;
 }

--- a/src/_entities/Feeds.ts
+++ b/src/_entities/Feeds.ts
@@ -5,7 +5,6 @@ import {
   JoinColumn,
   ManyToOne,
   OneToMany,
-  OneToOne,
   PrimaryGeneratedColumn,
 } from "typeorm";
 import { FeedCategoryMapping } from "./FeedCategoryMapping";
@@ -49,17 +48,17 @@ export class Feeds {
   })
   status: string;
 
-  @OneToOne(
+  @OneToMany(
     () => FeedCategoryMapping,
     (feedCategoryMapping) => feedCategoryMapping.feed
   )
-  feedCategoryMapping: FeedCategoryMapping;
+  feedCategoryMappings: FeedCategoryMapping[];
 
-  @OneToOne(
+  @OneToMany(
     () => FeedHashTagMapping,
     (feedHashTagMapping) => feedHashTagMapping.feed
   )
-  feedHashTagMapping: FeedHashTagMapping;
+  feedHashTagMappings: FeedHashTagMapping[];
 
   @OneToMany(() => FeedImgs, (feedImgs) => feedImgs.feed)
   feedImgs: FeedImgs[];
@@ -71,6 +70,6 @@ export class Feeds {
   @JoinColumn([{ name: "profileId", referencedColumnName: "profileId" }])
   profile: Profiles;
 
-  @OneToOne(() => Likes, (likes) => likes.feed)
-  likes: Likes;
+  @OneToMany(() => Likes, (likes) => likes.feed)
+  likes: Likes[];
 }

--- a/src/_entities/FollowFromTo.ts
+++ b/src/_entities/FollowFromTo.ts
@@ -1,32 +1,27 @@
-import {
-  Column,
-  Entity,
-  Index,
-  JoinColumn,
-  ManyToOne,
-  OneToOne,
-  PrimaryGeneratedColumn,
-} from "typeorm";
+import { Column, Entity, Index, JoinColumn, ManyToOne } from "typeorm";
 import { Profiles } from "./Profiles";
 
 @Index("FK_FollowFromTo_fiomUserId_Profiles_profileId", ["fiomUserId"], {})
 @Index("FK_FollowFromTo_toUserId_Profiles_profileId", ["toUserId"], {})
 @Entity("FollowFromTo", { schema: "devDB" })
 export class FollowFromTo {
+  @Column("int", { name: "fiomUserId", unsigned: true })
+  fiomUserId: number;
+
   @Column("int", { name: "toUserId", unsigned: true })
   toUserId: number;
 
-  @PrimaryGeneratedColumn({ type: "int", name: "fiomUserId", unsigned: true })
-  fiomUserId: number;
+  @Column("int", { primary: true, name: "id", unsigned: true })
+  id: number;
 
-  @OneToOne(() => Profiles, (profiles) => profiles.followFromTo, {
+  @ManyToOne(() => Profiles, (profiles) => profiles.followFromTos, {
     onDelete: "RESTRICT",
     onUpdate: "RESTRICT",
   })
   @JoinColumn([{ name: "fiomUserId", referencedColumnName: "profileId" }])
   fiomUser: Profiles;
 
-  @ManyToOne(() => Profiles, (profiles) => profiles.followFromTos, {
+  @ManyToOne(() => Profiles, (profiles) => profiles.followFromTos2, {
     onDelete: "RESTRICT",
     onUpdate: "RESTRICT",
   })

--- a/src/_entities/Likes.ts
+++ b/src/_entities/Likes.ts
@@ -1,19 +1,17 @@
-import {
-  Column,
-  Entity,
-  Index,
-  JoinColumn,
-  ManyToOne,
-  OneToOne,
-  PrimaryGeneratedColumn,
-} from "typeorm";
-import { Profiles } from "./Profiles";
+import { Column, Entity, Index, JoinColumn, ManyToOne } from "typeorm";
 import { Feeds } from "./Feeds";
+import { Profiles } from "./Profiles";
 
 @Index("FK_Likes_feedId_Feeds_feedId", ["feedId"], {})
 @Index("FK_Likes_profileId_Profiles_profileId", ["profileId"], {})
 @Entity("Likes", { schema: "devDB" })
 export class Likes {
+  @Column("int", { primary: true, name: "id", unsigned: true })
+  id: number;
+
+  @Column("int", { name: "feedId", unsigned: true })
+  feedId: number;
+
   @Column("int", { name: "profileId", unsigned: true })
   profileId: number;
 
@@ -23,8 +21,12 @@ export class Likes {
   })
   createdAt: Date;
 
-  @PrimaryGeneratedColumn({ type: "int", name: "feedId", unsigned: true })
-  feedId: number;
+  @ManyToOne(() => Feeds, (feeds) => feeds.likes, {
+    onDelete: "RESTRICT",
+    onUpdate: "RESTRICT",
+  })
+  @JoinColumn([{ name: "feedId", referencedColumnName: "feedId" }])
+  feed: Feeds;
 
   @ManyToOne(() => Profiles, (profiles) => profiles.likes, {
     onDelete: "RESTRICT",
@@ -32,11 +34,4 @@ export class Likes {
   })
   @JoinColumn([{ name: "profileId", referencedColumnName: "profileId" }])
   profile: Profiles;
-
-  @OneToOne(() => Feeds, (feeds) => feeds.likes, {
-    onDelete: "RESTRICT",
-    onUpdate: "RESTRICT",
-  })
-  @JoinColumn([{ name: "feedId", referencedColumnName: "feedId" }])
-  feed: Feeds;
 }

--- a/src/_entities/Notice.ts
+++ b/src/_entities/Notice.ts
@@ -1,0 +1,16 @@
+import { Column, Entity, PrimaryGeneratedColumn } from "typeorm";
+
+@Entity("Notice", { schema: "devDB" })
+export class Notice {
+  @PrimaryGeneratedColumn({ type: "int", name: "noticeId" })
+  noticeId: number;
+
+  @Column("text", { name: "content" })
+  content: string;
+
+  @Column("timestamp", {
+    name: "createdAt",
+    default: () => "CURRENT_TIMESTAMP",
+  })
+  createdAt: Date;
+}

--- a/src/_entities/ProfileHashTagMapping.ts
+++ b/src/_entities/ProfileHashTagMapping.ts
@@ -1,14 +1,12 @@
-import {
-  Column,
-  Entity,
-  Index,
-  JoinColumn,
-  ManyToOne,
-  OneToOne,
-} from "typeorm";
+import { Column, Entity, Index, JoinColumn, ManyToOne } from "typeorm";
 import { HashTags } from "./HashTags";
 import { Profiles } from "./Profiles";
 
+@Index(
+  "FK_ProfileHashTagMapping_profileId_Profiles_profileId",
+  ["profileId"],
+  {}
+)
 @Index(
   "FK_ProfileHashTagMapping_hashTagId_HashTags_hashTagId",
   ["hashTagId"],
@@ -16,7 +14,7 @@ import { Profiles } from "./Profiles";
 )
 @Entity("ProfileHashTagMapping", { schema: "devDB" })
 export class ProfileHashTagMapping {
-  @Column("int", { primary: true, name: "profileId", unsigned: true })
+  @Column("int", { name: "profileId", unsigned: true })
   profileId: number;
 
   @Column("int", { name: "hashTagId", unsigned: true })
@@ -28,6 +26,9 @@ export class ProfileHashTagMapping {
   })
   createdAt: Date;
 
+  @Column("int", { primary: true, name: "id", unsigned: true })
+  id: number;
+
   @ManyToOne(() => HashTags, (hashTags) => hashTags.profileHashTagMappings, {
     onDelete: "RESTRICT",
     onUpdate: "RESTRICT",
@@ -35,7 +36,7 @@ export class ProfileHashTagMapping {
   @JoinColumn([{ name: "hashTagId", referencedColumnName: "hashTagId" }])
   hashTag: HashTags;
 
-  @OneToOne(() => Profiles, (profiles) => profiles.profileHashTagMapping, {
+  @ManyToOne(() => Profiles, (profiles) => profiles.profileHashTagMappings, {
     onDelete: "RESTRICT",
     onUpdate: "RESTRICT",
   })

--- a/src/_entities/Profiles.ts
+++ b/src/_entities/Profiles.ts
@@ -5,18 +5,17 @@ import {
   JoinColumn,
   ManyToOne,
   OneToMany,
-  OneToOne,
   PrimaryGeneratedColumn,
 } from "typeorm";
 import { Feeds } from "./Feeds";
 import { FollowFromTo } from "./FollowFromTo";
 import { Likes } from "./Likes";
 import { ProfileHashTagMapping } from "./ProfileHashTagMapping";
-import { Users } from "./Users";
 import { Persona } from "./Persona";
+import { Users } from "./Users";
 
-@Index("FK_Profiles_personaId_Persona_personaId", ["personaId"], {})
 @Index("FK_Profiles_userId_Users_userId", ["userId"], {})
+@Index("FK_Profiles_personaId_Persona_personaId", ["personaId"], {})
 @Entity("Profiles", { schema: "devDB" })
 export class Profiles {
   @PrimaryGeneratedColumn({ type: "int", name: "profileId", unsigned: true })
@@ -34,7 +33,7 @@ export class Profiles {
   @Column("text", { name: "profileImgUrl" })
   profileImgUrl: string;
 
-  @Column("varchar", { name: "statusMessage", length: 100, default: ''})
+  @Column("varchar", { name: "statusMessage", length: 100 })
   statusMessage: string;
 
   @Column("timestamp", {
@@ -46,27 +45,20 @@ export class Profiles {
   @OneToMany(() => Feeds, (feeds) => feeds.profile)
   feeds: Feeds[];
 
-  @OneToOne(() => FollowFromTo, (followFromTo) => followFromTo.fiomUser)
-  followFromTo: FollowFromTo;
+  @OneToMany(() => FollowFromTo, (followFromTo) => followFromTo.fiomUser)
+  followFromTos: FollowFromTo[];
 
   @OneToMany(() => FollowFromTo, (followFromTo) => followFromTo.toUser)
-  followFromTos: FollowFromTo[];
+  followFromTos2: FollowFromTo[];
 
   @OneToMany(() => Likes, (likes) => likes.profile)
   likes: Likes[];
 
-  @OneToOne(
+  @OneToMany(
     () => ProfileHashTagMapping,
     (profileHashTagMapping) => profileHashTagMapping.profile
   )
-  profileHashTagMapping: ProfileHashTagMapping;
-
-  @ManyToOne(() => Users, (users) => users.profiles, {
-    onDelete: "RESTRICT",
-    onUpdate: "RESTRICT",
-  })
-  @JoinColumn([{ name: "userId", referencedColumnName: "userId" }])
-  user: Users;
+  profileHashTagMappings: ProfileHashTagMapping[];
 
   @ManyToOne(() => Persona, (persona) => persona.profiles, {
     onDelete: "RESTRICT",
@@ -74,4 +66,11 @@ export class Profiles {
   })
   @JoinColumn([{ name: "personaId", referencedColumnName: "personaId" }])
   persona: Persona;
+
+  @ManyToOne(() => Users, (users) => users.profiles, {
+    onDelete: "RESTRICT",
+    onUpdate: "RESTRICT",
+  })
+  @JoinColumn([{ name: "userId", referencedColumnName: "userId" }])
+  user: Users;
 }

--- a/src/_entities/QuestionContent.ts
+++ b/src/_entities/QuestionContent.ts
@@ -1,16 +1,11 @@
-import {
-  Column,
-  Entity,
-  Index,
-  JoinColumn,
-  OneToOne,
-  PrimaryGeneratedColumn,
-} from "typeorm";
+import { Column, Entity, JoinColumn, OneToOne } from "typeorm";
 import { Questions } from "./Questions";
 
-@Index("FK_QuestionContent_questionId_Questions_questionId", ["questionId"], {})
 @Entity("QuestionContent", { schema: "devDB" })
 export class QuestionContent {
+  @Column("int", { primary: true, name: "questionId", unsigned: true })
+  questionId: number;
+
   @Column("int", { name: "userId", unsigned: true })
   userId: number;
 
@@ -19,9 +14,6 @@ export class QuestionContent {
 
   @Column("timestamp", { name: "createdAt" })
   createdAt: Date;
-
-  @PrimaryGeneratedColumn({ type: "int", name: "questionId", unsigned: true })
-  questionId: number;
 
   @OneToOne(() => Questions, (questions) => questions.questionContent, {
     onDelete: "RESTRICT",

--- a/src/_entities/Users.ts
+++ b/src/_entities/Users.ts
@@ -6,28 +6,29 @@ export class Users {
   @PrimaryGeneratedColumn({ type: "int", name: "userId", unsigned: true })
   userId: number;
 
-  @Column("text", { name: "alarm_token", nullable: true })
-  alarmToken: string | null;
+  @Column("text", { name: "alarm_token" })
+  alarmToken: string;
 
   @Column("varchar", { name: "email", nullable: true, length: 100 })
   email: string | null;
 
-  @Column("varchar", { name: "password", nullable: true, length: 255 })
+  @Column("text", { name: "password", nullable: true })
   password: string | null;
-
-  @Column("varchar", {
-    name: "status",
-    comment: "ACTIVE,INACTIVE,DELETED",
-    length: 45,
-    default: () => "'ACTIVE'",
-  })
-  status: string;
 
   @Column("timestamp", {
     name: "createdAt",
+    nullable: true,
     default: () => "CURRENT_TIMESTAMP",
   })
-  createdAt: Date;
+  createdAt: Date | null;
+
+  @Column("varchar", {
+    name: "status",
+    nullable: true,
+    length: 45,
+    default: () => "'ACTIVE'",
+  })
+  status: string | null;
 
   @OneToMany(() => Profiles, (profiles) => profiles.user)
   profiles: Profiles[];

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -4,6 +4,9 @@ import { AppService } from './app.service';
 import { ConfigModule } from '@nestjs/config';
 import { TypeOrmModule } from '@nestjs/typeorm';
 import { ProfilesModule } from './profiles/profiles.module';
+import { PersonaModule } from './persona/persona.module';
+import { AuthModule } from './auth/auth.module';
+import { JwtMiddleware } from './_middleware/jwt.middleware';
 import { Categories } from './_entities/Categories';
 import { FeedCategoryMapping } from './_entities/FeedCategoryMapping';
 import { FeedHashTagMapping } from './_entities/FeedHashTagMapping';
@@ -18,9 +21,6 @@ import { Profiles } from './_entities/Profiles';
 import { QuestionContent } from './_entities/QuestionContent';
 import { Questions } from './_entities/Questions';
 import { Users } from './_entities/Users';
-import { PersonaModule } from './persona/persona.module';
-import { AuthModule } from './auth/auth.module';
-import { JwtMiddleware } from './_middleware/jwt.middleware';
 
 @Module({
   imports: [
@@ -51,7 +51,7 @@ import { JwtMiddleware } from './_middleware/jwt.middleware';
         Questions,
         Users,
       ],
-      synchronize: true,
+      synchronize: false,
     }),
     ProfilesModule,
     PersonaModule,

--- a/src/ormconfig.json
+++ b/src/ormconfig.json
@@ -6,8 +6,8 @@
     "port": 3306,
     "username": "root",
     "password": "p@ssword",
-    "database": "devDB",
+    "database": "",
     "synchronize": false,
-    "entities": ["entities/*.js"]
+    "entities": ["_entities/*.js"]
   }
 ]


### PR DESCRIPTION
## 📢 관련 이슈
- #8 

## 📃 작업 사항
- 현재(23.01.14.) ERD를 기준으로 엔티티 재생성
  - 엔티티 디렉토리는 `/src/_entities`로 동일 (언더바는 엔티티 디렉토리 상단에 올리기 위해)
- `app.module.ts`에서 TypeORM `synchronize` 기능 false로 수정하여 엔티티에 의한 DB 수정 방지