### PR TITLE
hotfix: 컴파일 된 자바스크립트 파일이 아닌 nest 서버를 실행하도록 변경

### DIFF
--- a/.github/workflows/dev.yml
+++ b/.github/workflows/dev.yml
@@ -25,4 +25,4 @@ jobs:
             pm2 kill
             npm i --force
             npm run build
-            pm2 start dist/main.js
+            pm2 start npm -- run start:dev


### PR DESCRIPTION
## 📢 관련 이슈
- [x] #27 #35 

## 📃 작업 사항
- 자바스크립트 파일이 아닌 nest 서버를 실행하도록 배포 스크립트 변경