### PR TITLE
merge: 프로필 CRUD 과정에서 JWT 이용하도록 수정

### DIFF
--- a/src/_utilities/baseResponseStatus.ts
+++ b/src/_utilities/baseResponseStatus.ts
@@ -27,6 +27,7 @@ const baseResponse = {
   PROFILE_SAME_PERSONA: { statusCode: 1501, message: '사용자에게 해당 페르소나가 이미 존재합니다.' },
   PROFILE_NOT_EXIST: { statusCode: 1502, message: '해당 프로필은 존재하지 않습니다.' },
   USER_NO_PROFILE: { statusCode: 1503, message: '해당 사용자는 프로필이 존재하지 않습니다.' },
+  PROFILE_NO_AUTHENTICATION: { statusCode: 1504, message: '해당 프로필에 대한 권한이 없습니다.' },
 
 
   // 좋아요 관련

--- a/src/profiles/dto/createProfile.dto.ts
+++ b/src/profiles/dto/createProfile.dto.ts
@@ -2,11 +2,6 @@ import { ApiProperty } from '@nestjs/swagger';
 import { IsNotEmpty, IsNumber, IsOptional, IsString, MaxLength } from 'class-validator';
 
 export class CreateProfileDto {
-  @ApiProperty({ description: '사용자 ID', example: 1 })
-  @IsNotEmpty()
-  @IsNumber()
-  userId: number;
-
   @ApiProperty({ description: '프로필 이름', example: '작가 야옹이' })
   @IsNotEmpty()
   @MaxLength(20)

--- a/src/profiles/dto/editProfile.dto.ts
+++ b/src/profiles/dto/editProfile.dto.ts
@@ -2,11 +2,6 @@ import { ApiProperty } from '@nestjs/swagger';
 import { IsNotEmpty, IsNumber, IsOptional, IsString, MaxLength } from 'class-validator';
 
 export class EditProfileDto {
-  @ApiProperty({ description: '사용자 ID', example: 1 })
-  @IsNotEmpty()
-  @IsNumber()
-  userId: number;
-
   @ApiProperty({ description: '프로필 이름', example: '작가 야옹이' })
   @IsNotEmpty()
   @MaxLength(20)

--- a/src/profiles/dto/profile.model.ts
+++ b/src/profiles/dto/profile.model.ts
@@ -10,7 +10,6 @@ export interface ProfileModel {
 
 export const ProfileModelExample = {
   profileId: 30,
-  userId: 2,
   profileName: '(프로필 이름)',
   personaId: 1,
   profileImgUrl: '(프로필 이미지)',

--- a/src/profiles/profiles.controller.ts
+++ b/src/profiles/profiles.controller.ts
@@ -193,11 +193,11 @@ export class ProfilesController {
     schema: { example: errResponse(baseResponse.USER_NO_PROFILE) },
   })
   @UseGuards(JWTAuthGuard)
-  @Get('/myProfiles/:userId')
+  @Get('/myProfiles')
   getUserProfilesList(
-    @Param('userId', ParseIntPipe) userId: number
+    @Request() req: any
   ) {
-    return this.profilesService.getUserProfilesList(userId);
+    return this.profilesService.getUserProfilesList(req);
   }
 
   // API No. 2.5 타유저 프로필

--- a/src/profiles/profiles.controller.ts
+++ b/src/profiles/profiles.controller.ts
@@ -109,6 +109,11 @@ export class ProfilesController {
     description: 'profileId에 해당하는 프로필이 없는 경우',
     schema: { example: errResponse(baseResponse.PROFILE_NOT_EXIST) },
   })
+  @ApiResponse({
+    status: 1504,
+    description: '자신의 프로필이 아닌 경우',
+    schema: { example: errResponse(baseResponse.PROFILE_NO_AUTHENTICATION) },
+  })
   @UseGuards(JWTAuthGuard)
   @Post('/delete')
   deleteProfile(
@@ -150,6 +155,11 @@ export class ProfilesController {
     description: 'profileId에 해당하는 프로필이 없는 경우',
     schema: { example: errResponse(baseResponse.PROFILE_NOT_EXIST) },
   })
+  @ApiResponse({
+    status: 1504,
+    description: '자신의 프로필이 아닌 경우',
+    schema: { example: errResponse(baseResponse.PROFILE_NO_AUTHENTICATION) },
+  })
   @UseGuards(JWTAuthGuard)
   @Post('/edit/:profileId')
   editProfile(
@@ -164,7 +174,7 @@ export class ProfilesController {
   // 프로필 변경을 할 수 있도록 사용자의 모든 프로필을 제공
   @ApiOperation({
     summary: '사용자 프로필 목록 가져오기',
-    description: '멀티 페르소나를 위해 사용자의 모든 프로필 목록을 가져오는 API',
+    description: '멀티 페르소나를 위해 사용자의 모든 프로필 목록을 가져오는 API (Header의 JWT를 제외한 별도 데이터 필요 X)',
   })
   @ApiBearerAuth('Authorization')
   @ApiResponse({
@@ -191,6 +201,11 @@ export class ProfilesController {
     status: 1503,
     description: '사용자의 프로필이 없는 경우',
     schema: { example: errResponse(baseResponse.USER_NO_PROFILE) },
+  })
+  @ApiResponse({
+    status: 1504,
+    description: '자신의 프로필이 아닌 경우',
+    schema: { example: errResponse(baseResponse.PROFILE_NO_AUTHENTICATION) },
   })
   @UseGuards(JWTAuthGuard)
   @Get('/myProfiles')

--- a/src/profiles/profiles.controller.ts
+++ b/src/profiles/profiles.controller.ts
@@ -87,7 +87,7 @@ export class ProfilesController {
   @ApiResponse({
     status: 100,
     description: 'SUCCESS',
-    schema: { example: sucResponse(baseResponse.SUCCESS, { profileId: 25 }) },
+    schema: { example: sucResponse(baseResponse.SUCCESS) },
   })
   @ApiResponse({
     status: 400,
@@ -154,9 +154,10 @@ export class ProfilesController {
   @Post('/edit/:profileId')
   editProfile(
     @Param('profileId', ParseIntPipe) profileId: number,
+    @Request() req: any,
     @Body() editProfileDto: EditProfileDto,
   ) {
-    return this.profilesService.editProfile(profileId, editProfileDto);
+    return this.profilesService.editProfile(req, profileId, editProfileDto);
   }
 
   // API No. 1.2 프로필 변경

--- a/src/profiles/profiles.controller.ts
+++ b/src/profiles/profiles.controller.ts
@@ -5,6 +5,7 @@ import {
   Param,
   ParseIntPipe,
   Post,
+  Request,
   UseGuards,
   UsePipes,
   ValidationPipe,
@@ -69,8 +70,11 @@ export class ProfilesController {
   @UseGuards(JWTAuthGuard)
   @Post('/create')
   @UsePipes(ValidationPipe)
-  createProfile(@Body() createProfileDto: CreateProfileDto) {
-    return this.profilesService.createProfile(createProfileDto);
+  createProfile(
+    @Body() createProfileDto: CreateProfileDto,
+    @Request() req: any
+  ) {
+    return this.profilesService.createProfile(req, createProfileDto);
   }
 
   // API No. 3.1 프로필 삭제

--- a/src/profiles/profiles.controller.ts
+++ b/src/profiles/profiles.controller.ts
@@ -80,7 +80,7 @@ export class ProfilesController {
   // API No. 3.1 프로필 삭제
   @ApiOperation({
     summary: '프로필 삭제',
-    description: '프로필 삭제에 관한 API이며 현재 삭제 방식에 대한 논의 중',
+    description: '프로필 삭제에 관한 API',
   })
   @ApiBearerAuth('Authorization')
   @ApiBody({ schema: { example: { profileId: 1 } } })
@@ -111,8 +111,11 @@ export class ProfilesController {
   })
   @UseGuards(JWTAuthGuard)
   @Post('/delete')
-  deleteProfile(@Body('profileId', ParseIntPipe) profileId: number) {
-    return this.profilesService.deleteProfile(profileId);
+  deleteProfile(
+    @Body('profileId', ParseIntPipe) profileId: number,
+    @Request() req: any
+  ) {
+    return this.profilesService.deleteProfile(req, profileId);
   }
   
   // API No. 3.1 프로필 수정

--- a/src/profiles/profiles.repository.ts
+++ b/src/profiles/profiles.repository.ts
@@ -35,12 +35,16 @@ export class ProfilesRepository {
     return await this.profilesTable.delete(profileId);
   }
 
-  // 프로필 업데이트
+  // 프로필 업데이트 (업데이트를 수행한 후, 수정된 프로필을 return)
   async editProfile(profileId: number, editProfileDto: EditProfileDto) {
-    return await this.profilesTable.update(profileId, {
+    await this.profilesTable.update(profileId, {
       profileName: editProfileDto.profileName,
       profileImgUrl: editProfileDto.profileImgUrl,
       statusMessage: editProfileDto.statusMessage
     })
+
+    const editResult = await this.findProfileByProfileId(profileId);
+
+    return editResult;
   }
 }

--- a/src/profiles/profiles.service.ts
+++ b/src/profiles/profiles.service.ts
@@ -15,10 +15,9 @@ export class ProfilesService {
   ) {}
 
   // 프로필 생성
-  async createProfile(createProfileDto: CreateProfileDto): Promise<any> {
-    const userProfilesList = await this.profileRepository.getUserProfilesList(
-      createProfileDto.userId,
-    );
+  async createProfile(req: any, createProfileDto: CreateProfileDto): Promise<any> {
+    const requestUserId = req.user.userId;
+    const userProfilesList = await this.profileRepository.getUserProfilesList(requestUserId);
     const newProfilePersonaName = createProfileDto.personaName;
 
     // 프로필 갯수 validation
@@ -54,7 +53,7 @@ export class ProfilesService {
 
     // 새로운 프로필 생성
     const newProfileDto: SaveProfileDto = {
-      userId: createProfileDto.userId,
+      userId: requestUserId,
       profileName: createProfileDto.profileName,
       personaId: newProfilePeronaId,
       profileImgUrl: createProfileDto.profileImgUrl,

--- a/src/profiles/profiles.service.ts
+++ b/src/profiles/profiles.service.ts
@@ -94,15 +94,22 @@ export class ProfilesService {
   }
 
   // 프로필 수정
-  async editProfile(profileId: number, editProfileDto: EditProfileDto) {
+  async editProfile(req: any, profileId: number, editProfileDto: EditProfileDto) {
     try {
-      const editResult = await this.profileRepository.editProfile(profileId, editProfileDto);
+      const requestUserId = req.user.userId;
+      const targetProfile = await this.profileRepository.findProfileByProfileId(profileId);
 
-      if (editResult.affected === 0) {
+      if (targetProfile?.userId !== requestUserId) {
+        return errResponse(baseResponse.PROFILE_NO_AUTHENTICATION);
+      }
+
+      // 해당 프로필이 존재하지 않는 경우
+      if (!targetProfile) {
         return errResponse(baseResponse.PROFILE_NOT_EXIST);
       }
 
-      const editedProfile = await this.profileRepository.findProfileByProfileId(profileId);
+      const editedProfile = await this.profileRepository.editProfile(profileId, editProfileDto);
+      delete editedProfile.userId;
 
       return sucResponse(baseResponse.SUCCESS, editedProfile);
     } catch (error) {

--- a/src/profiles/profiles.service.ts
+++ b/src/profiles/profiles.service.ts
@@ -133,10 +133,12 @@ export class ProfilesService {
   }
 
   // 사용자의 모든 프로필 가져오기
-  async getUserProfilesList(userId: number) {
+  async getUserProfilesList(req: any) {
     try {
-      const profileList = await this.profileRepository.getUserProfilesList(userId);
+      const requestUserId = req.user.userId;
+      const profileList = await this.profileRepository.getUserProfilesList(requestUserId);
 
+      // 사용자의 프로필이 존재하지 않는 경우
       if (profileList.length === 0) {
         return errResponse(baseResponse.USER_NO_PROFILE);
       }

--- a/src/profiles/profiles.service.ts
+++ b/src/profiles/profiles.service.ts
@@ -70,14 +70,22 @@ export class ProfilesService {
   }
 
   // 프로필 삭제
-  async deleteProfile(profileId: number) {
+  async deleteProfile(req: any, profileId: number) {
     try {
-      const result = await this.profileRepository.deleteProfile(profileId);
+      const requestUserId = req.user.userId;
+      const targetProfile = await this.profileRepository.findProfileByProfileId(profileId);
 
+      // 요청의 userId와 삭제 대상 프로필의 userId가 다른 경우
+      if (targetProfile?.userId !== requestUserId) {
+        return errResponse(baseResponse.PROFILE_NO_AUTHENTICATION);
+      }
+      
       // profileId에 해당하는 프로필이 없는 경우
-      if (result.affected === 0) {
+      if (!targetProfile) {
         return errResponse(baseResponse.PROFILE_NOT_EXIST);
       }
+      
+      await this.profileRepository.deleteProfile(profileId);
 
       return sucResponse(baseResponse.SUCCESS);
     } catch (error) {


### PR DESCRIPTION
## 📃 작업 사항
- userId를 Request의 Body로 넘겨주는 것에서 JWT에서 직접 추출하여 사용하도록 변경
  - 따라서, Request Body에 userId가 들어가는 일이 없음
  - 사용자와 프로필 관련된 API 들에서 유효한 JWT를 이용해 프로필의 소유자가 맞는지 확인하는 과정 추가