### PR TITLE
카카오 로그인 기능 추가

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -20,6 +20,7 @@
         "@types/bcrypt": "^5.0.0",
         "@types/cookie-parser": "^1.4.3",
         "@types/passport-jwt": "^3.0.8",
+        "axios": "^1.2.2",
         "bcrypt": "^5.1.0",
         "class-transformer": "^0.5.1",
         "class-validator": "^0.13.2",
@@ -1734,6 +1735,15 @@
         }
       }
     },
+    "node_modules/@nestjs/common/node_modules/axios": {
+      "version": "0.27.2",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-0.27.2.tgz",
+      "integrity": "sha512-t+yRIyySRTp/wua5xEr+z1q60QmLq8ABsS5O9Me1AsE5dfKqgnCFzwiCZZ/cGNd1lq4/7akDWMxdhVlucjmnOQ==",
+      "dependencies": {
+        "follow-redirects": "^1.14.9",
+        "form-data": "^4.0.0"
+      }
+    },
     "node_modules/@nestjs/config": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/@nestjs/config/-/config-2.2.0.tgz",
@@ -3193,12 +3203,13 @@
       }
     },
     "node_modules/axios": {
-      "version": "0.27.2",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-0.27.2.tgz",
-      "integrity": "sha512-t+yRIyySRTp/wua5xEr+z1q60QmLq8ABsS5O9Me1AsE5dfKqgnCFzwiCZZ/cGNd1lq4/7akDWMxdhVlucjmnOQ==",
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.2.2.tgz",
+      "integrity": "sha512-bz/J4gS2S3I7mpN/YZfGFTqhXTYzRho8Ay38w2otuuDR322KzFIWm/4W2K6gIwvWaws5n+mnb7D1lN9uD+QH6Q==",
       "dependencies": {
-        "follow-redirects": "^1.14.9",
-        "form-data": "^4.0.0"
+        "follow-redirects": "^1.15.0",
+        "form-data": "^4.0.0",
+        "proxy-from-env": "^1.1.0"
       }
     },
     "node_modules/babel-jest": {
@@ -9021,6 +9032,11 @@
         "node": ">= 0.10"
       }
     },
+    "node_modules/proxy-from-env": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
+      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg=="
+    },
     "node_modules/pseudomap": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/pseudomap/-/pseudomap-1.0.2.tgz",
@@ -12688,6 +12704,17 @@
         "iterare": "1.2.1",
         "tslib": "2.4.0",
         "uuid": "8.3.2"
+      },
+      "dependencies": {
+        "axios": {
+          "version": "0.27.2",
+          "resolved": "https://registry.npmjs.org/axios/-/axios-0.27.2.tgz",
+          "integrity": "sha512-t+yRIyySRTp/wua5xEr+z1q60QmLq8ABsS5O9Me1AsE5dfKqgnCFzwiCZZ/cGNd1lq4/7akDWMxdhVlucjmnOQ==",
+          "requires": {
+            "follow-redirects": "^1.14.9",
+            "form-data": "^4.0.0"
+          }
+        }
       }
     },
     "@nestjs/config": {
@@ -13822,12 +13849,13 @@
       "integrity": "sha512-+q/t7Ekv1EDY2l6Gda6LLiX14rU9TV20Wa3ofeQmwPFZbOMo9DXrLbOjFaaclkXKWidIaopwAObQDqwWtGUjqg=="
     },
     "axios": {
-      "version": "0.27.2",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-0.27.2.tgz",
-      "integrity": "sha512-t+yRIyySRTp/wua5xEr+z1q60QmLq8ABsS5O9Me1AsE5dfKqgnCFzwiCZZ/cGNd1lq4/7akDWMxdhVlucjmnOQ==",
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.2.2.tgz",
+      "integrity": "sha512-bz/J4gS2S3I7mpN/YZfGFTqhXTYzRho8Ay38w2otuuDR322KzFIWm/4W2K6gIwvWaws5n+mnb7D1lN9uD+QH6Q==",
       "requires": {
-        "follow-redirects": "^1.14.9",
-        "form-data": "^4.0.0"
+        "follow-redirects": "^1.15.0",
+        "form-data": "^4.0.0",
+        "proxy-from-env": "^1.1.0"
       }
     },
     "babel-jest": {
@@ -18276,6 +18304,11 @@
         "forwarded": "0.2.0",
         "ipaddr.js": "1.9.1"
       }
+    },
+    "proxy-from-env": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
+      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg=="
     },
     "pseudomap": {
       "version": "1.0.2",

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "@types/bcrypt": "^5.0.0",
     "@types/cookie-parser": "^1.4.3",
     "@types/passport-jwt": "^3.0.8",
+    "axios": "^1.2.2",
     "bcrypt": "^5.1.0",
     "class-transformer": "^0.5.1",
     "class-validator": "^0.13.2",

--- a/src/_config/kakao.config.ts
+++ b/src/_config/kakao.config.ts
@@ -1,4 +1,7 @@
 export const kakaoConfig = {
+  kakaoAuthHost: 'https://kauth.kakao.com',
   kakaoTokenUrl: 'https://kauth.kakao.com/oauth/token',
   kakaoUserInfoUrl: 'https://kapi.kakao.com/v2/user/me',
+  kakaoLogoutUrl: 'https://kapi.kakao.com/v1/user/logout',
+  kakaoUnlinkUrl: 'https://kapi.kakao.com/v1/user/unlink',
 };

--- a/src/_config/kakao.config.ts
+++ b/src/_config/kakao.config.ts
@@ -1,0 +1,4 @@
+export const kakaoConfig = {
+  kakaoTokenUrl: 'https://kauth.kakao.com/oauth/token',
+  kakaoUserInfoUrl: 'https://kapi.kakao.com/v2/user/me',
+};

--- a/src/_utilities/baseResponseStatus.ts
+++ b/src/_utilities/baseResponseStatus.ts
@@ -21,6 +21,7 @@ const baseResponse = {
   KAKAO_AUTH_CODE_EMPTY: { statusCode: 1003, message: '카카오 인가코드가 없습니다.' },
   KAKAO_ACCESS_TOKEN_FAIL: { statusCode: 1004, message: '카카오 인증토큰을 받는데 실패하였습니다.' },
   KAKAO_USER_INFO_FAIL: { statusCode: 1005, message: '카카오 유저 정보를 불러오는데 실패하였습니다.' },
+  KAKAO_LOGOUT_FAILED: { statusCode: 1006, message: '카카오 로그아웃에 실패했습니다.' },
 
   // 회원, 계정 관련
   USER_ALREADY_EXISTS: { statusCode: 1010, message: '이미 가입된 회원입니다.' },

--- a/src/_utilities/baseResponseStatus.ts
+++ b/src/_utilities/baseResponseStatus.ts
@@ -20,8 +20,9 @@ const baseResponse = {
   KAKAO_LOGIN_FAILED: { statusCode: 1002, message: '카카오 로그인에 실패했습니다.' },
   KAKAO_AUTH_CODE_EMPTY: { statusCode: 1003, message: '카카오 인가코드가 없습니다.' },
   KAKAO_ACCESS_TOKEN_FAIL: { statusCode: 1004, message: '카카오 인증토큰을 받는데 실패하였습니다.' },
-  KAKAO_USER_INFO_FAIL: { statusCode: 1005, message: '카카오 유저 정보를 불러오는데 실패하였습니다.' },
-  KAKAO_LOGOUT_FAILED: { statusCode: 1006, message: '카카오 로그아웃에 실패했습니다.' },
+  KAKAO_ACCESS_TOKEN_EMPTY: { statusCode: 1005, message: '카카오 인증토큰이 없습니다.' },
+  KAKAO_USER_INFO_FAIL: { statusCode: 1006, message: '카카오 유저 정보를 불러오는데 실패하였습니다.' },
+  KAKAO_LOGOUT_FAILED: { statusCode: 1007, message: '카카오 로그아웃에 실패했습니다.' },
 
   // 회원, 계정 관련
   USER_ALREADY_EXISTS: { statusCode: 1010, message: '이미 가입된 회원입니다.' },

--- a/src/_utilities/baseResponseStatus.ts
+++ b/src/_utilities/baseResponseStatus.ts
@@ -17,6 +17,10 @@ const baseResponse = {
   // 인증 관련
   AUTH_COOKIE_JWT_EMPTY: { statusCode: 1000, message: '쿠키에 jwt가 없습니다.' },
   TOKEN_VERIFICATION_FAILURE: { statusCode: 1001, message: 'JWT 토큰 검증 실패' },
+  KAKAO_LOGIN_FAILED: { statusCode: 1002, message: '카카오 로그인에 실패했습니다.' },
+  KAKAO_AUTH_CODE_EMPTY: { statusCode: 1003, message: '카카오 인가코드가 없습니다.' },
+  KAKAO_ACCESS_TOKEN_FAIL: { statusCode: 1004, message: '카카오 인증토큰을 받는데 실패하였습니다.' },
+  KAKAO_USER_INFO_FAIL: { statusCode: 1005, message: '카카오 유저 정보를 불러오는데 실패하였습니다.' },
 
   // 회원, 계정 관련
   USER_ALREADY_EXISTS: { statusCode: 1010, message: '이미 가입된 회원입니다.' },

--- a/src/auth/auth.controller.ts
+++ b/src/auth/auth.controller.ts
@@ -6,7 +6,7 @@ import { Request, Response } from 'express';
 import { errResponse, sucResponse } from '../_utilities/response';
 import baseResponse from '../_utilities/baseResponseStatus';
 import { UserService } from './user.service';
-import {ApiBearerAuth, ApiBody, ApiHeader, ApiOperation, ApiResponse, ApiTags} from '@nestjs/swagger';
+import { ApiBearerAuth, ApiBody, ApiOperation, ApiResponse, ApiTags } from '@nestjs/swagger';
 
 @ApiTags('로그인, 인증 API')
 @Controller('auth')
@@ -95,7 +95,7 @@ export class AuthController {
     res.setHeader('Authorization', 'Bearer ' + jwtResult.accessToken);
     res.cookie('jwt', jwtResult.accessToken, {
       // domain: 'OnAndOff Login',
-      httpOnly: true,              // 브라우저에서의 쿠키 사용 막기 (XSS등의 보안강화용)
+      httpOnly: true, // 브라우저에서의 쿠키 사용 막기 (XSS등의 보안강화용)
       // maxAge: 24 * 60 * 60 * 1000, // 1day
     });
 
@@ -175,5 +175,19 @@ export class AuthController {
     });
 
     return res.send(sucResponse(baseResponse.SUCCESS));
+  }
+
+  // API No. 4.1.1.1. 카카오 로그인
+  @Post('/kakao-login')
+  async kakaoLogin(@Body() body: any): Promise<any> {
+    // 1. 클라이언트로부터 인가 코드 전달 받기
+    const { code } = body;
+    if (!code) {
+      return errResponse(baseResponse.KAKAO_AUTH_CODE_EMPTY);
+    }
+
+    const kakaoResult = await this.authService.kakaoLogin(code);
+
+    return kakaoResult;
   }
 }

--- a/src/auth/auth.module.ts
+++ b/src/auth/auth.module.ts
@@ -8,6 +8,7 @@ import { JwtModule } from '@nestjs/jwt';
 import { PassportModule } from '@nestjs/passport';
 import { JwtStrategy } from './security/passport.jwt.strategy';
 import { jwtConfig } from '../_config/jwt.config';
+import { KakaoLogin } from './kakao/kakao.service';
 
 @Module({
   imports: [
@@ -17,6 +18,6 @@ import { jwtConfig } from '../_config/jwt.config';
   ],
   exports: [AuthService],
   controllers: [AuthController],
-  providers: [AuthService, UserService, JwtStrategy],
+  providers: [AuthService, UserService, JwtStrategy, KakaoLogin],
 })
 export class AuthModule {}

--- a/src/auth/dto/user.dto.ts
+++ b/src/auth/dto/user.dto.ts
@@ -7,7 +7,7 @@ export class UserDTO {
   @IsString()
   @MaxLength(100)
   email: string;
-  @ApiProperty({ description: '비밀번호. (자체로그인에만 사용됩니다.)', example: 'test' })
+  @ApiProperty({ description: '비밀번호. (자체로그인에만 필수로 사용됩니다.)', example: 'test', required: true })
   @IsString()
   @MaxLength(255)
   password: string | null;

--- a/src/auth/dto/user.dto.ts
+++ b/src/auth/dto/user.dto.ts
@@ -7,9 +7,8 @@ export class UserDTO {
   @IsString()
   @MaxLength(100)
   email: string;
-  @ApiProperty({ description: '비밀번호', example: 'test', required: true })
-  @IsNotEmpty()
+  @ApiProperty({ description: '비밀번호. (자체로그인에만 사용됩니다.)', example: 'test' })
   @IsString()
   @MaxLength(255)
-  password: string;
+  password: string | null;
 }

--- a/src/auth/kakao/kakao.service.ts
+++ b/src/auth/kakao/kakao.service.ts
@@ -1,0 +1,173 @@
+import { Injectable } from '@nestjs/common';
+import { AuthService } from '../auth.service';
+import { UserService } from '../user.service';
+import axios from 'axios';
+import { kakaoConfig } from '../../_config/kakao.config';
+import * as qs from 'qs';
+import { errResponse, sucResponse } from '../../_utilities/response';
+import baseResponse from '../../_utilities/baseResponseStatus';
+
+@Injectable()
+export class KakaoLogin {
+  check: boolean;
+  // kakaoAccessToken: string;
+
+  kakaoKey: string;
+  kakaoRedirectUrl: string;
+  // const kakaoTokenUrl = 'https://kauth.kakao.com/oauth/token';
+  // const kakaoUserInfoUrl = 'https://kapi.kakao.com/v2/user/me';
+
+  constructor(
+    private authService: AuthService,
+    private userService: UserService,
+  ) {
+    this.check = false;
+    // this.kakaoAccessToken = '';
+    this.kakaoKey = process.env.KAKAO_REST_API_KEY;
+    this.kakaoRedirectUrl = process.env.KAKAO_REDIRECT_URL;
+  }
+
+  loginCheck(): void {
+    this.check = !this.check;
+    return;
+  }
+
+  // (로컬에서) 카카오 액세스 토큰을 잠시 저장해두기 위해 만든 함수
+  // setToken(token: string): boolean {
+  //   this.kakaoAccessToken = token;
+  //   return true;
+  // }
+
+  // 카카오의 access token으로 카카오 유저 정보 불러오기
+  async getKakaoUserInfoByToken(accessToken: any): Promise<any> {
+    const headerUserInfo = {
+      'Content-Type': 'application/x-www-form-urlencoded;charset=utf-8',
+      Authorization: `Bearer ${accessToken}`,
+    };
+
+    try {
+      const kakaoUserInfoResponse = await axios({
+        method: 'GET',
+        url: kakaoConfig.kakaoUserInfoUrl,
+        timeout: 30000,
+        headers: headerUserInfo,
+      });
+
+      const kakaoUserInfo = kakaoUserInfoResponse.data;
+      // console.log(kakaoUserInfo);
+
+      return kakaoUserInfo;
+    } catch (e) {
+      console.log(`kakaoUserInfoResponse Error : ${e}`);
+
+      // [Validation 처리]
+      // 응답이 잘 안 온 경우
+      return errResponse(baseResponse.KAKAO_USER_INFO_FAIL);
+      // ---
+    }
+  }
+
+  async kakaoLogin(code: any): Promise<any> {
+    const headers = {
+      'Content-Type': 'application/x-www-form-urlencoded;charset=utf-8',
+    };
+    const body = {
+      grant_type: 'authorization_code',
+      client_id: this.kakaoKey,
+      redirect_url: this.kakaoRedirectUrl,
+      code: code,
+    };
+
+    let kakaoAccessToken;
+    // 2. 카카오에게 인가 코드를 보내고 액세스 토큰 받기
+    try {
+      const kakaoTokenResponse = await axios({
+        method: 'POST',
+        url: kakaoConfig.kakaoTokenUrl,
+        timeout: 30000,
+        headers,
+        data: qs.stringify(body),
+      });
+
+      const kakaoTokenInfo = kakaoTokenResponse.data;
+      // console.log(kakaoTokenInfo);
+      kakaoAccessToken = kakaoTokenInfo.access_token;
+      // console.log(`kakaoAccessToken: ${kakaoAccessToken}`);
+
+      // (로컬에서) 로그아웃을 위해 카카오 액세스 토큰 저장해두기
+      // this.setToken(kakaoTokenInfo.access_token);
+    } catch (e) {
+      // console.log(`kakaoTokenResponse Error: ${e}`);
+
+      // [Validation 처리]
+      // 응답이 잘 안 온 경우 (access token을 못 받은 경우)
+      return errResponse(baseResponse.KAKAO_ACCESS_TOKEN_FAIL);
+      // ---
+    }
+
+    // if (kakaoTokenResponse.status !== 200) {
+    if (kakaoAccessToken === '' || kakaoAccessToken === undefined) {
+      return errResponse(baseResponse.KAKAO_ACCESS_TOKEN_FAIL);
+    }
+
+    // 3. 액세스 토큰으로 카카오 유저 정보 가져오기
+    const kakaoUserInfo = await this.getKakaoUserInfoByToken(kakaoAccessToken);
+    const kakaoUserEmail = kakaoUserInfo.kakao_account.email;
+    // console.log(kakaoUserEmail);
+
+    // 4. 서비스 회원가입 or 로그인 처리
+    const socialUserResult = await this.authService.handleSocialUser(kakaoUserEmail);
+    // console.log(socialUserResult);
+
+    // 5. 카카오 access token, 회원가입/로그인 한 userId, 서비스 jwt, 이메일(?) 반환
+    const result = {
+      message: socialUserResult.message,
+      kakaoAccessToken: kakaoAccessToken,
+      serviceJwt: socialUserResult.jwt,
+      socialUserId: socialUserResult.userId,
+    };
+
+    return result;
+  }
+
+  async kakaoLogout(accessToken: any): Promise<any> {
+    // console.log(`LOGOUT TOKEN : ${accessToken}`);
+
+    const headerUserInfo = {
+      'Content-Type': 'application/x-www-form-urlencoded;charset=utf-8',
+      Authorization: `Bearer ${accessToken}`,
+    };
+
+    // 방법1. 토큰 만료 (logout) - 로그아웃
+    try {
+      const kakaoLogoutResponse = await axios({
+        method: 'POST',
+        url: kakaoConfig.kakaoLogoutUrl,
+        timeout: 30000,
+        headers: headerUserInfo,
+      });
+
+      // console.log(kakaoLogoutResponse);
+
+      // (로컬에서) 저장해둔 토큰 해제하기
+      // this.setToken('');
+
+      return sucResponse(baseResponse.SUCCESS);
+    } catch (e) {
+      console.log(`kakaoLogoutResponse Error: ${e}`);
+      return errResponse(baseResponse.KAKAO_LOGOUT_FAILED);
+    }
+
+    // 방법2. 연결 끊기 (unlink) - 탈퇴 or 다른 카카오 아이디로 로그인
+    // try {
+    //   const kakaoUnlinkResponse = await axios({
+    //     method: 'POST',
+    //     url: kakaoConfig.kakaoUnlinkUrl,
+    //     timeout: 30000,
+    //     headers: headerUserInfo,
+    //   });
+    // } catch (e) {
+    //   console.log(`kakaoUnlinkResponse Error: ${e}`);
+    // }
+  }
+}

--- a/src/auth/user.service.ts
+++ b/src/auth/user.service.ts
@@ -27,7 +27,7 @@ export class UserService {
     return userInfo;
   }
 
-  // 이메일+비밀번호 로 회원 1명 검색하기
+  // 조건으로 회원 1명 검색하기 (ex. 이메일+비밀번호)
   async findByFields(
     options: FindOneOptions<UserDTO>,
   ): Promise<Users | undefined> {
@@ -36,8 +36,10 @@ export class UserService {
 
   // 이메일+비밀번호 로 회원을 DB에 저장하기
   async save(userDTO: UserDTO): Promise<Users | undefined> {
-    // 비밀번호 암호화
-    await this.transformPassword(userDTO);
+    if (userDTO.password !== null) {
+      // 비밀번호 암호화
+      await this.transformPassword(userDTO);
+    }
     // console.log(userDTO);
 
     return await this.userRepository.save(userDTO);


### PR DESCRIPTION
## 📢 관련 이슈
- [x] #7 

## 📃 작업 사항
- 카카오 로그인 기능 추가
   - 카카오 로그인 -> 카카오 계정을 통해 사용자 인증 -> 서비스 회원가입/로그인 -> 로그인
   - 계정 인증은 카카오를 통해서, 서비스 이용은 '이메일'을 통해서
   - 만약 유저 데이터에 이메일이 이미 있으면 로그인, 없으면 새로 회원가입하고 로그인
   - 카카오와 관련된 내용은 '카카오 access token'을 통해서, 서비스와 관련된 내용은 '서비스 jwt' (자체 로그인과 마찬가지) 를 통해서
- 카카오 로그인 swagger 작성 추가