### PR TITLE
hotfix: 타유저 프로필 조회시 userId 반환하지 않도록 수정

### DIFF
--- a/src/profiles/profiles.service.ts
+++ b/src/profiles/profiles.service.ts
@@ -126,6 +126,8 @@ export class ProfilesService {
         return errResponse(baseResponse.PROFILE_NOT_EXIST);
       }
 
+      delete result.userId;
+
       return sucResponse(baseResponse.SUCCESS, result);
     } catch (error) {
       return errResponse(baseResponse.DB_ERROR);


### PR DESCRIPTION
## 📃 작업 사항
- userId가 요청과 응답에 노출되지 않기 위해 response 결과에서 삭제