### PR TITLE
fix: 프로필 수정에 이미지 변경할 수 있도록 기능 추가

### DIFF
--- a/src/profiles/controller/profiles.controller.ts
+++ b/src/profiles/controller/profiles.controller.ts
@@ -142,7 +142,7 @@ export class ProfilesController {
   @ApiOperation({
     summary: '프로필 수정',
     description:
-      '프로필을 생성하는 경우와 Body가 유사하지만, 페르소나는 변경이 불가능하므로 프로필 수정 Body에서는 제외된다.',
+      '프로필을 생성하는 경우와 Body가 유사하지만, 페르소나는 변경이 불가능하므로 프로필 수정 Body에서는 제외됩니다.\n\nprofileName, statusMessage, image를 받아야 하며 statusMessage와 image는 생략이 가능합니다.\n\nimage를 보내지 않는 경우는 기본 프로필 이미지로 수정됩니다.\n\n자세한 내용은 노션을 참고해주세요.',
   })
   @ApiBearerAuth('Authorization')
   @ApiResponse({
@@ -177,12 +177,14 @@ export class ProfilesController {
   })
   @UseGuards(JWTAuthGuard)
   @Post('/edit/:profileId')
+  @UseInterceptors(FileInterceptor('image'))
   editProfile(
     @Param('profileId', ParseIntPipe) profileId: number,
+    @UploadedFile() image: Express.Multer.File,
     @Request() req: any,
     @Body() editProfileDto: EditProfileDto,
   ) {
-    return this.profilesService.editProfile(req, profileId, editProfileDto);
+    return this.profilesService.editProfile(profileId, image, req, editProfileDto);
   }
 
   // API No. 1.2 프로필 변경

--- a/src/profiles/dto/editProfile.dto.ts
+++ b/src/profiles/dto/editProfile.dto.ts
@@ -7,15 +7,7 @@ export class EditProfileDto {
   @MaxLength(20)
   @IsString()
   profileName: string;
-
-  @ApiProperty({
-    description: '프로필 이미지 URL',
-    example: 'https://imgURL.com',
-  })
-  @IsNotEmpty()
-  @IsString()
-  profileImgUrl: string;
-
+  
   @ApiProperty({
     description: '상태 메시지',
     example: '작가가 되고싶은 야옹이',
@@ -24,4 +16,11 @@ export class EditProfileDto {
   @IsOptional()
   @MaxLength(100)
   statusMessage: string;
+
+  @ApiProperty({
+    description: '프로필 이미지 파일',
+    example: 'profileImg.png',
+    required: false,
+  })
+  image: object;
 }

--- a/src/profiles/profiles.repository.ts
+++ b/src/profiles/profiles.repository.ts
@@ -36,12 +36,8 @@ export class ProfilesRepository {
   }
 
   // 프로필 업데이트 (업데이트를 수행한 후, 수정된 프로필을 return)
-  async editProfile(profileId: number, editProfileDto: EditProfileDto) {
-    await this.profilesTable.update(profileId, {
-      profileName: editProfileDto.profileName,
-      profileImgUrl: editProfileDto.profileImgUrl,
-      statusMessage: editProfileDto.statusMessage
-    })
+  async editProfile(profileId: number, newContent: object ) {
+    await this.profilesTable.update(profileId, newContent);
 
     const editResult = await this.findProfileByProfileId(profileId);
 


### PR DESCRIPTION
## 📃 작업 사항
- 프로필 수정에도 S3를 적용
  - 이미지가 Body에 있는 경우: 기존 이미지(기본 프로필 이미지가 아닌 경우)는 삭제 처리하고 새로운 이미지를 저장(S3의 공간 낭비 방지)
  - 이미지가 Body에 없는 경우: 기존 이미지(기본 프로필 이미지가 이닌 경우)를 삭제하고 기본 프로필 이미지로 변경