### PR TITLE
feat 캘린더에서 특정일 조회 기능 구현

### DIFF
--- a/src/feeds/feeds.controller.ts
+++ b/src/feeds/feeds.controller.ts
@@ -63,9 +63,10 @@ export class FeedsController {
 
     @Get('/my-feeds/by-month')
     @ApiOperation({
-        summary: '프로필 (게시글모아보기) API 3.1.2',
-        description: '마이페이지에서 월별 게시글 모아보기 기능이다. year과 month를 통해 그달에 포스팅한 게시글들을 모아볼 수 있다.\n\
-                      pagination으로 동작한다.' ,
+        summary: '프로필 (게시글모아보기) API 3.1.2/기능명세서 1.4(1).1 해당일 게시글 모아보기',
+        description: 'A: 프로필 (게시글모아보기) API 3.1.2: 마이페이지에서 월별 게시글 모아보기 기능이다. year과 month를 통해 그달에 포스팅한 게시글들을 모아볼 수 있다.\n\
+                      pagination으로 동작한다.\
+                      B: 기능명세서 1.4(1).1 해당일 게시글 모아보기 기능이다. 홈화면 달력에서 날짜를 클릭시 동작한다. year,month,day를 통해 해당일에 등록된 게시글을 조회한다.' ,
     })
     @ApiQuery({
         name: 'profileId',
@@ -83,6 +84,11 @@ export class FeedsController {
         description:'검색하고싶은 달 "mm"형식으로 제공되어야한다.(2자리수) ex) 01'
     })
     @ApiQuery({
+        name: 'day',
+        required:false,
+        description:'프로필 (게시글모아보기) API 3.1.2 에선 사용되지 않는다. 기능명세서 1.4(1).1 해당일 게시글 모아보기에서만 사용된다.'
+    })
+    @ApiQuery({
         name: 'page',
         required:true,
         description:'pagination을 통해 scroll하면서 10개씩 정보를 받아온다. 현재 몇번째 정보를 받아와야하는지를 넘겨주시면 됩니다.\n\
@@ -98,12 +104,13 @@ export class FeedsController {
         @Query('profileId') profileId:number,
         @Query('year') year:number,
         @Query('month') month:number,
+        @Query('day') day:number,
         @Query('page') pageNumber: number
     ){
-        return this.feedsService.RetreiveMyFeedByMonth(profileId,year,month,pageNumber);
+        return this.feedsService.RetreiveMyFeedByMonth(profileId,year,month,day,pageNumber);
     }
 
-    @Get('/my-feeds/in-calender')
+    @Get('/my-feeds/in-calendar')
     @ApiOperation({
         summary: '홈화면(캘런더) 1.4.1',
         description: '홈화면에서 캘런더를 통해 내가 게시글을 쓴 날이 표시되는 API이다.' ,

--- a/src/feeds/feeds.repository.ts
+++ b/src/feeds/feeds.repository.ts
@@ -33,20 +33,29 @@ export class FeedRepository{
         return found;
     }
 
-    retrieveMyFeedByMonth(profileId: number, year: number, month: number,pageNumber:number) {
+    retrieveMyFeedByMonth(profileId: number, year: number, month: number,day:number,pageNumber:number) {
         
-        const this_month=year+"-"+month;
-        console.log(this_month);
+        
 
-        const found=this.feedTable
+        const query=this.feedTable
             .createQueryBuilder('Feeds')
             .leftJoinAndSelect('Feeds.feedImgs','feedImg')
             .where("Feeds.profileId=:profileId",{profileId:profileId})
-            .andWhere('DATE_FORMAT(`Feeds`.`createdAt`, "%Y-%m")=:target',{target:this_month})
             .skip(10*(pageNumber-1))
             .take(10)
-            .getMany();
-        return found;
+            
+            console.log(day)
+            if(day==null){
+                console.log("day is null");
+                const target_date=year+"-"+month;
+                query.andWhere('DATE_FORMAT(`Feeds`.`createdAt`, "%Y-%m")=:target',{target:target_date});
+            }else{
+                console.log("day is not null");
+                const target_date=year+"-"+month+"-"+day;
+                query.andWhere('DATE_FORMAT(`Feeds`.`createdAt`, "%Y-%m-%d")=:target',{target:target_date});
+            }
+
+        return query.getMany();
     }
 
     RetriveMyFeedInCalender(profileId: number, year: number, month: number) {

--- a/src/feeds/feeds.service.ts
+++ b/src/feeds/feeds.service.ts
@@ -50,8 +50,8 @@ export class FeedsService {
         return foundDTO;
     }
 
-    async RetreiveMyFeedByMonth(profileId: number, year: number, month: number,pageNumber:number) :Promise<RetreiveMyFeedByMonthReturnDTO>{
-        const feedEntity:Feeds[]=await this.feedRepsitory.retrieveMyFeedByMonth(profileId,year,month,pageNumber);
+    async RetreiveMyFeedByMonth(profileId: number, year: number, month: number,day:number,pageNumber:number) :Promise<RetreiveMyFeedByMonthReturnDTO>{
+        const feedEntity:Feeds[]=await this.feedRepsitory.retrieveMyFeedByMonth(profileId,year,month,day,pageNumber);
 
         console.log(feedEntity);
         const foundDTO:RetreiveMyFeedByMonthReturnDTO=new RetreiveMyFeedByMonthReturnDTO(feedEntity);


### PR DESCRIPTION
## 📃 작업 사항
- 기능명세서 1.4(1).1 해당일 게시글 모아보기 구현
- 기존 월단위 게시글 모아보기 기능 API를 수정하여 Parameter로 day추가하였다.
