### PR TITLE
[feat/docs] @UseGuards를 통해 JWT인증 모듈을 붙임/swagger에 표현

### DIFF
--- a/src/following/controller/following.controller.ts
+++ b/src/following/controller/following.controller.ts
@@ -1,5 +1,13 @@
-import { Body, Controller, Get, Post } from '@nestjs/common';
-import { ApiCreatedResponse, ApiOperation, ApiQuery, ApiResponse, ApiTags } from '@nestjs/swagger';
+import { Body, Controller, Get, Post, UseGuards } from '@nestjs/common';
+import {
+  ApiBearerAuth,
+  ApiCreatedResponse,
+  ApiOperation,
+  ApiQuery,
+  ApiResponse,
+  ApiTags,
+} from '@nestjs/swagger';
+import { JWTAuthGuard } from '../../auth/security/auth.guard.jwt';
 import baseResponse from '../../common/utils/baseResponseStatus';
 import { sucResponse } from '../../common/utils/response';
 import { PostFollowRequestDTO } from '../dto/post-follow.dto';
@@ -8,30 +16,33 @@ import { FollowingService } from '../service/following.service';
 @Controller('follow')
 @ApiTags('Feed API')
 export class FollowingController {
-    constructor(private followingService:FollowingService){};
+  constructor(private followingService: FollowingService) {}
 
-    @Post()
-    @ApiOperation({
-        summary: '둘러보기 API 2.1.3 팔로잉 설정/해제 기능',
-        description: '둘러보기 탐색에서 화면에서 사용되는 API이다. 둘러보기 탐색중에 마음에드는 프로필에 팔로우 설정/해제 할 수 있다.\n\
-                      팔로우상태에서는 팔로우가 해제 되고 팔로우를 안한상태에서는 팔로우상태가 된다.'
-    })
-    @ApiResponse({
-        status: 2101,
-        description: '팔로우 설정',
-        schema: { example: sucResponse(baseResponse.POST_FOLLOW) },
-    })
-    @ApiResponse({
-        status: 2102,
-        description: '팔로우 해제',
-        schema: { example: sucResponse(baseResponse.DELETE_FOLLOW) },
-    })
-    postFollow(
-        @Body() postFollowRequestDTO:PostFollowRequestDTO
-    ){
-        //following follower 유효한지 체크해야함.
+  @Post()
+  @ApiOperation({
+    summary: '둘러보기 API 2.1.3 팔로잉 설정/해제 기능',
+    description:
+      '둘러보기 탐색에서 화면에서 사용되는 API이다. 둘러보기 탐색중에 마음에드는 프로필에 팔로우 설정/해제 할 수 있다.\n\
+                      팔로우상태에서는 팔로우가 해제 되고 팔로우를 안한상태에서는 팔로우상태가 된다.',
+  })
+  @ApiResponse({
+    status: 2101,
+    description: '팔로우 설정',
+    schema: { example: sucResponse(baseResponse.POST_FOLLOW) },
+  })
+  @ApiResponse({
+    status: 2102,
+    description: '팔로우 해제',
+    schema: { example: sucResponse(baseResponse.DELETE_FOLLOW) },
+  })
+  @ApiBearerAuth('Authorization')
+  @UseGuards(JWTAuthGuard)
+  postFollow(@Body() postFollowRequestDTO: PostFollowRequestDTO) {
+    //following follower 유효한지 체크해야함.
 
-        return this.followingService.postFollow(postFollowRequestDTO.fromProfileId,postFollowRequestDTO.toProfileId);
-
-    }
+    return this.followingService.postFollow(
+      postFollowRequestDTO.fromProfileId,
+      postFollowRequestDTO.toProfileId,
+    );
+  }
 }

--- a/src/likes/controller/likes.controller.ts
+++ b/src/likes/controller/likes.controller.ts
@@ -1,5 +1,6 @@
-import { Body, Controller, Post } from '@nestjs/common';
-import { ApiOperation, ApiResponse, ApiTags } from '@nestjs/swagger';
+import { Body, Controller, Post, UseGuards } from '@nestjs/common';
+import { ApiBearerAuth, ApiOperation, ApiResponse, ApiTags } from '@nestjs/swagger';
+import { JWTAuthGuard } from '../../auth/security/auth.guard.jwt';
 import baseResponse from '../../common/utils/baseResponseStatus';
 import { sucResponse } from '../../common/utils/response';
 import { PostLikeRequestDTO } from '../dto/post-like.dto';
@@ -26,6 +27,8 @@ export class LikesController {
         description: '좋아요 해제',
         schema: { example: sucResponse(baseResponse.DELETE_LIKE) },
     })
+    @ApiBearerAuth('Authorization')
+    @UseGuards(JWTAuthGuard)
     postLikes(
         @Body() postLikeRequestDTO: PostLikeRequestDTO
     ){


### PR DESCRIPTION
## 📢 관련 이슈
- POST follow/like API에 대해 로그인 인증 모듈이 붙어있지 않았다.

## 📃 작업 사항
- POST follow/like API에 대해 로그인 인증 모듈을 붙이고 Swagger에서 확인할 수 있도록 하였다.