### PR TITLE
[fix]  isSecret이 PUBLIC인 경우에만 조회

### DIFF
--- a/src/feeds/feeds.repository.ts
+++ b/src/feeds/feeds.repository.ts
@@ -62,12 +62,13 @@ export class FeedRepository {
       .leftJoinAndSelect('Feeds.profile', 'profiles')
       .leftJoinAndSelect('profiles.persona', 'persona')
       .leftJoinAndSelect('Feeds.feedImgs', 'feedImg')
-      .leftJoinAndSelect('Feeds.categories', 'category');
+      .leftJoinAndSelect('Feeds.categories', 'category')
+      .where('Feeds.isSecret=:isSecret',{isSecret: "PUBLIC"});
 
     if (categoryId != 0) {
       //0이 아닐때는 categoryId를 통한 필터링
       foundQuery
-        .where('Feeds.categoryId=:category', { category: categoryId })
+        .andWhere('Feeds.categoryId=:category', { category: categoryId })
         .skip(10 * (pageNumber - 1))
         .take(10);
     } else {


### PR DESCRIPTION
## 📢 관련 이슈
- 둘러보기 API에서 isSecret이 PUBLIC인 경우에만 조회해야하는데 이부분 필터링이 없었다.

## 📃 작업 사항
- feedRepository의 retrieveFeed 메소드 에서 where문을 통해 필터링 시켜 주었다.
- 팔로우 둘러보기 기능에서도 참고바람
