### PR TITLE
[refactor] 프로필 검증 로직 변경

### DIFF
--- a/src/common/utils/baseResponseStatus.ts
+++ b/src/common/utils/baseResponseStatus.ts
@@ -59,7 +59,11 @@ const baseResponse = {
   FEED_IS_SECRET_CAN_HAVE_PUBLIC_OR_PRIVATE:{statusCode:2203,message:'게시글의 isSecret으로는 PUBLIC OR PRIVATE만 가능합니다..'},
   FEED_CAN_HAVE_20_HASHTAGS:{statusCode:2204,message:'게시글은 최대 20개까지 해시태그를 가질 수 있습니다.'},
   FEED_IMG_COUNT_OVER:{statusCode:2205,message:'게시글이미지는 최대 5개로 제한됩니다.'},
-  FEED_HAVE_CONTENT_OR_IMAGE:{statusCode:2206,message:'게시글은 내용 OR 이미지 중 적어도 하나는 가져야 합니다.'}
+  FEED_HAVE_CONTENT_OR_IMAGE:{statusCode:2206,message:'게시글은 내용 OR 이미지 중 적어도 하나는 가져야 합니다.'},
+
+  // 검색 관련
+  HASHTAG_NOT_FOUND: { statusCode: 2500, message: '해시태그를 입력해주세요.' },
+
   // 수치화 관련
 };
 

--- a/src/feeds/controller/feeds.controller.ts
+++ b/src/feeds/controller/feeds.controller.ts
@@ -383,4 +383,33 @@ export class FeedsController {
   reportFeeds(@Body('feedId', ParseIntPipe) feedId: number) {
     return this.feedsService.reportFeeds(feedId);
   }
+
+  // API No. 2.3.1 해시태그 검색
+  // @UseGuards(JWTAuthGuard)
+  // @Get('/feedlist/:profileId/search')
+  // searchFeeds(
+  //   @Param('profileId', ParseIntPipe) profileId: number,
+  //   @Query('hashtag') hashtag: string,
+  //   @Query('page') pageNumber: number,
+  //   @Query('categoryId') categoryId: number,) {
+  //   // [Validation 처리]
+  //   // profileId 가 있는가
+  //   if (!profileId) {
+  //     return errResponse(baseResponse.PROFILE_ID_NOT_FOUND);
+  //   }
+  //   // jwt 토큰 유저 정보와 profileId 가 맞게 매칭되어 있는가
+  //   // const checkProfileMatch = await this.statisticsService.checkProfile(user.userId, profileId);
+  //   // console.log(checkProfileMatch);
+  //
+  //   // if (!checkProfileMatch) {
+  //   //   return errResponse(baseResponse.PROFILE_NOT_MATCH);
+  //   // }
+  //   // 해시태그가 있는가
+  //   if (!hashtag) {
+  //     return errResponse(baseResponse.HASHTAG_NOT_FOUND);
+  //   }
+  //   // ---
+  //
+  //   return this.feedsService.searchFeedsByHashtag(hashtag);
+  // }
 }

--- a/src/feeds/service/feeds.service.ts
+++ b/src/feeds/service/feeds.service.ts
@@ -376,4 +376,46 @@ export class FeedsService {
 
     return sucResponse(baseResponse.SUCCESS);
   }
+
+  async searchFeedsByHashtag(hashtag: string): Promise<any> {
+    // 1. 해시태그가 있는지 검색
+    const hashTagEntity = await this.hashTagRepository.findByName(hashtag);
+    // console.log(hashTagEntity);
+    // 해시태그가 없는 경우 (검색 결과 없음)
+    if (hashTagEntity.length <= 0) {
+      return sucResponse(baseResponse.SUCCESS, {
+        message: '검색 결과가 없습니다',
+      });
+    }
+    // 해시태그가 있는 경우
+    const hashTagId = hashTagEntity[0].hashTagId;
+    // 2. 해시태그 ID를 통해 게시글 검색
+    // let foundDTO: retrieveFeedsReturnDto;
+    // const feedEntity = await this.feedRepsitory.retrieveFeeds(
+    //   profileId,
+    //   pageNumber,
+    //   categoryId,
+    // );
+    // const feedIdList = [];
+    //
+    // console.log(feedEntity);
+    // if (feedEntity.length == 0) {
+    //   return errResponse(baseResponse.FEED_NOT_FOUND);
+    // }
+    // for (let i = 0; i < feedEntity.length; i++) {
+    //   feedIdList.push(feedEntity[i].feedId);
+    // }
+    // const isLikeEntity = await this.likeRepository.isLike(
+    //   feedIdList,
+    //   profileId,
+    // );
+    // console.log(feedEntity);
+    //
+    // foundDTO = new retrieveFeedsReturnDto(feedEntity, isLikeEntity);
+    //
+    // // console.log(util.inspect(foundDTO, {showHidden: false, depth: null}));
+    // return foundDTO;
+
+    return undefined;
+  }
 }

--- a/src/profiles/profiles.repository.ts
+++ b/src/profiles/profiles.repository.ts
@@ -48,4 +48,13 @@ export class ProfilesRepository {
 
     return editResult;
   }
+
+  async checkUserProfileMatch(userId, profileId: number) {
+    return await this.profilesTable.find({
+      where: {
+        profileId: profileId,
+        userId: userId,
+      },
+    });
+  }
 }

--- a/src/profiles/service/profiles.service.ts
+++ b/src/profiles/service/profiles.service.ts
@@ -219,4 +219,15 @@ export class ProfilesService {
       return errResponse(baseResponse.DB_ERROR);
     }
   }
+
+  async checkProfile(userId, profileId: number) {
+    const profileInfo = await this.profileRepository.checkUserProfileMatch(userId, profileId);
+    // console.log(profileInfo);
+
+    if (profileInfo.length > 0) {
+      return true;
+    } else {
+      return false;
+    }
+  }
 }

--- a/src/statistics/controller/statistics.controller.ts
+++ b/src/statistics/controller/statistics.controller.ts
@@ -5,11 +5,15 @@ import { JWTAuthGuard } from '../../auth/security/auth.guard.jwt';
 import { Request, Response } from 'express';
 import { errResponse, sucResponse } from '../../common/utils/response';
 import baseResponse from '../../common/utils/baseResponseStatus';
+import { ProfilesService } from '../../profiles/service/profiles.service';
 
 @ApiTags('수치화 API')
 @Controller('statistics')
 export class StatisticsController {
-  constructor(private statisticsService: StatisticsService) {}
+  constructor(
+    private statisticsService: StatisticsService,
+    private profilesService: ProfilesService,
+  ) {}
 
   // TODO: 1.5.1 ~ 1.5.3 을 한번에 불러올지, 각각 따로 불러올지?
   // API No. 1.5.0 수치화 - 전체
@@ -71,7 +75,7 @@ export class StatisticsController {
       return errResponse(baseResponse.PROFILE_ID_NOT_FOUND);
     }
     // jwt 토큰 유저 정보와 profileId 가 맞게 매칭되어 있는가
-    const checkProfileMatch = await this.statisticsService.checkProfile(user.userId, profileId);
+    const checkProfileMatch = await this.profilesService.checkProfile(user.userId, profileId);
     // console.log(checkProfileMatch);
 
     if (!checkProfileMatch) {
@@ -150,7 +154,7 @@ export class StatisticsController {
       return errResponse(baseResponse.PROFILE_ID_NOT_FOUND);
     }
     // jwt 토큰 유저 정보와 profileId 가 맞게 매칭되어 있는가
-    const checkProfileMatch = await this.statisticsService.checkProfile(user.userId, profileId);
+    const checkProfileMatch = await this.profilesService.checkProfile(user.userId, profileId);
     // console.log(checkProfileMatch);
 
     if (!checkProfileMatch) {
@@ -225,7 +229,7 @@ export class StatisticsController {
       return errResponse(baseResponse.PROFILE_ID_NOT_FOUND);
     }
     // jwt 토큰 유저 정보와 profileId 가 맞게 매칭되어 있는가
-    const checkProfileMatch = await this.statisticsService.checkProfile(user.userId, profileId);
+    const checkProfileMatch = await this.profilesService.checkProfile(user.userId, profileId);
     // console.log(checkProfileMatch);
 
     if (!checkProfileMatch) {
@@ -300,7 +304,7 @@ export class StatisticsController {
       return errResponse(baseResponse.PROFILE_ID_NOT_FOUND);
     }
     // jwt 토큰 유저 정보와 profileId 가 맞게 매칭되어 있는가
-    const checkProfileMatch = await this.statisticsService.checkProfile(user.userId, profileId);
+    const checkProfileMatch = await this.profilesService.checkProfile(user.userId, profileId);
     // console.log(checkProfileMatch);
 
     if (!checkProfileMatch) {

--- a/src/statistics/service/statistics.service.ts
+++ b/src/statistics/service/statistics.service.ts
@@ -72,20 +72,4 @@ export class StatisticsService {
 
     return myFollowersCount;
   }
-
-  async checkProfile(userId, profileId: number) {
-    const profileInfo = await this.profilesRepository.find({
-      where: {
-        profileId: profileId,
-        userId: userId,
-      },
-    });
-    // console.log(profileInfo);
-
-    if (profileInfo.length > 0) {
-      return true;
-    } else {
-      return false;
-    }
-  }
 }

--- a/src/statistics/statistics.module.ts
+++ b/src/statistics/statistics.module.ts
@@ -6,11 +6,25 @@ import { Likes } from '../common/entities/Likes';
 import { Feeds } from '../common/entities/Feeds';
 import { FollowFromTo } from '../common/entities/FollowFromTo';
 import { Profiles } from '../common/entities/Profiles';
+import { ProfilesService } from "../profiles/service/profiles.service";
+import { ProfilesRepository } from "../profiles/profiles.repository";
+import { Persona } from "../common/entities/Persona";
+import { PersonaRepository } from "../persona/persona.repository";
+import { AwsService } from "../aws/aws.service";
 
+// TODO: Module-Controller-Service-(Repository) 구조 리팩토링? - Service와 Repository를 나눠야하는가?
 @Module({
-  imports: [TypeOrmModule.forFeature([Likes, Feeds, FollowFromTo, Profiles])],
-  exports: [StatisticsService],
+  imports: [
+    TypeOrmModule.forFeature([Likes, Feeds, FollowFromTo, Profiles, Persona]),
+  ],
+  exports: [StatisticsService, ProfilesRepository, PersonaRepository],
   controllers: [StatisticsController],
-  providers: [StatisticsService],
+  providers: [
+    StatisticsService,
+    ProfilesService,
+    ProfilesRepository,
+    PersonaRepository,
+    AwsService,
+  ],
 })
 export class StatisticsModule {}


### PR DESCRIPTION
## 📢 관련 이슈
- [x] #76 

## 📃 작업 사항
- 수치화 리팩토링
	- profileId와 jwt를 비교하여 매칭이 올바른지 확인하는 validation
	- 기존 statistics 도메인에 있던 로직을 profiles 도메인으로 옮김 <TODO>
- Service 리팩토링
	- 기존 Service를 Service+Repository로 나눈 구조를 Service 하나로 통합하는 방식은 어떤지 확인 필요
	- 현재까지 확인된 바로는, 다른 도메인의 Service를 가져오기 더 쉬워질 것이라 예상됨

## TODO
- 해시태그 검색 기능 구현 도중 리팩토링 진행함 -> 해시태그 관련 코드들은 현재 주석처리되어 있음
