### PR TITLE
[fix] 프로필 관련 API들이 personaId 대신 personaName을 반환하도록 수정

### DIFF
--- a/src/profiles/controller/profiles.controller.ts
+++ b/src/profiles/controller/profiles.controller.ts
@@ -28,7 +28,7 @@ import baseResponse from '../../common/utils/baseResponseStatus';
 import { errResponse, sucResponse } from '../../common/utils/response';
 import { CreateProfileDto } from '../dto/createProfile.dto';
 import { EditProfileDto } from '../dto/editProfile.dto';
-import { ProfileModelExample } from '../dto/profile.model';
+import { ProfileModelExample, ProfileResponseModelExample } from '../dto/profile.model';
 import { ProfilesService } from '../service/profiles.service';
 
 @ApiTags('Profiles')
@@ -148,7 +148,7 @@ export class ProfilesController {
   @ApiResponse({
     status: 100,
     description: 'SUCCESS',
-    schema: { example: sucResponse(baseResponse.SUCCESS, ProfileModelExample) },
+    schema: { example: sucResponse(baseResponse.SUCCESS, ProfileResponseModelExample) },
   })
   @ApiResponse({
     status: 400,
@@ -199,16 +199,7 @@ export class ProfilesController {
     status: 100,
     description: 'SUCCESS',
     schema: {
-      example: sucResponse(baseResponse.SUCCESS, [
-        {
-          "profileId": 29,
-          "personaName": "개발자",
-          "profileName": "야옹이",
-          "statusMessage": "나는 개발자다~!",
-          "profileImgUrl": "https://imag.url",
-          "createdAt": "2023-01-16T22:02:27.000Z"
-        },
-      ]),
+      example: sucResponse(baseResponse.SUCCESS, [ProfileResponseModelExample, ProfileResponseModelExample]),
     },
   })
   @ApiResponse({
@@ -252,7 +243,7 @@ export class ProfilesController {
   @ApiResponse({
     status: 100,
     description: 'SUCCESS',
-    schema: { example: sucResponse(baseResponse.SUCCESS, ProfileModelExample) },
+    schema: { example: sucResponse(baseResponse.SUCCESS, ProfileResponseModelExample) },
   })
   @ApiResponse({
     status: 400,

--- a/src/profiles/controller/profiles.controller.ts
+++ b/src/profiles/controller/profiles.controller.ts
@@ -142,7 +142,7 @@ export class ProfilesController {
   @ApiOperation({
     summary: '프로필 수정',
     description:
-      '프로필을 생성하는 경우와 Body가 유사하지만, 페르소나는 변경이 불가능하므로 프로필 수정 Body에서는 제외됩니다.\n\nprofileName, statusMessage, image, defaultImage를 받아야 하며 image는 생략이 가능합니다.\n\nstatusMessage가 비어있는 경우는 빈 문자열을 보내주시면 됩니다\n\ndefaultImage와 image의 작동은 아래와 같습니다\n\n1. defaultImage: true && image: 있음/없음 -> 기본 이미지로 변경\n\n2. defaultImage: false && image: 있음 -> 새로운 이미지로 변경\n\n3. defaultImage: false && image: 없음 -> 기존 이미지\n\n자세한 내용은 노션을 참고해주세요.',
+      '프로필을 생성하는 경우와 Body가 유사하지만, 페르소나는 변경이 불가능하므로 프로필 수정 Body에서는 제외됩니다.\n\nprofileName, statusMessage, image, defaultImage를 받아야 하며 image는 생략이 가능합니다.\n\nstatusMessage가 비어있는 경우는 빈 문자열을 보내주시면 됩니다\n\ndefaultImage와 image의 작동은 아래와 같습니다\n\n1. defaultImage: true && image: 있음/없음 -> 기본 이미지로 변경\n\n2. defaultImage: false && image: 있음 -> 새로운 이미지로 변경\n\n3. defaultImage: false && image: 없음 -> 기존 이미지\n\n자세한 내용은 노션을 참고해주세요.\n\nform-data에는 boolean 타입이 들어가지 않는 것으로 보여 true(boolean) 또는 "true"(string)으로 보내주시면 됩니다. (단, 대소문자 구분)',
   })
   @ApiBearerAuth('Authorization')
   @ApiResponse({

--- a/src/profiles/controller/profiles.controller.ts
+++ b/src/profiles/controller/profiles.controller.ts
@@ -239,7 +239,6 @@ export class ProfilesController {
     description:
       'API No. 2.5 타유저 프로필 등에서 활용 가능하도록 프로필 ID를 이용해 프로필 정보를 받아오는 API',
   })
-  @ApiBearerAuth('Authorization')
   @ApiResponse({
     status: 100,
     description: 'SUCCESS',
@@ -265,7 +264,6 @@ export class ProfilesController {
     description: 'profileId에 해당하는 프로필이 없는 경우',
     schema: { example: errResponse(baseResponse.PROFILE_NOT_EXIST) },
   })
-  @UseGuards(JWTAuthGuard)
   @Get('/:profileId')
   getProfileByProfileId(@Param('profileId', ParseIntPipe) profileId: number) {
     return this.profilesService.getProfileByProfileId(profileId);

--- a/src/profiles/dto/createProfile.dto.ts
+++ b/src/profiles/dto/createProfile.dto.ts
@@ -2,7 +2,7 @@ import { ApiProperty } from '@nestjs/swagger';
 import { IsNotEmpty, IsOptional, IsString, MaxLength } from 'class-validator';
 
 export class CreateProfileDto {
-  @ApiProperty({ description: '프로필 이름', example: '작가 야옹이' })
+  @ApiProperty({ description: '프로필 이름', example: '야옹이' })
   @IsNotEmpty()
   @MaxLength(20)
   @IsString()

--- a/src/profiles/dto/editProfile.dto.ts
+++ b/src/profiles/dto/editProfile.dto.ts
@@ -28,9 +28,9 @@ export class EditProfileDto {
   image: object;
 
   @ApiProperty({
-    description: '기본 프로필 이미지로 변경 여부 (true로 들어오는 경우 이미지의 유무와 상관없이 기본 프로필 이미지로 변경됩니다)',
+    description: '기본 프로필 이미지로 변경 여부 (true로 들어오는 경우 이미지의 유무와 상관없이 기본 프로필 이미지로 변경됩니다)\n\nform-data에는 boolean 타입이 들어가지 않는 것으로 보여 true(boolean) 또는 "true"(string)으로 보내주시면 됩니다. (단, 대소문자 구분)',
     example: true,
     required: true,
   })
-  defaultImage: boolean;
+  defaultImage: boolean | string;
 }

--- a/src/profiles/dto/editProfile.dto.ts
+++ b/src/profiles/dto/editProfile.dto.ts
@@ -32,5 +32,5 @@ export class EditProfileDto {
     example: true,
     required: true,
   })
-  defaultImage: boolean | string;
+  defaultImage: string | boolean;
 }

--- a/src/profiles/dto/profile.model.ts
+++ b/src/profiles/dto/profile.model.ts
@@ -26,3 +26,12 @@ export const ProfileModelExample = {
   statusMessage: '(프로필 상태 메시지)',
   createdAt: '(프로필 생성 날짜)',
 };
+
+export const ProfileResponseModelExample = {
+  profileId: 29,
+  personaName: '(페르소나 이름)',
+  profileName: '(프로필 이름)',
+  statusMessage: '(프로필 상태 메시지)',
+  profileImgUrl: '(프로필 이미지)',
+  createdAt: '(프로필 생성 날짜)',
+};

--- a/src/profiles/service/profiles.service.ts
+++ b/src/profiles/service/profiles.service.ts
@@ -196,8 +196,6 @@ export class ProfilesService {
         return errResponse(baseResponse.PROFILE_NOT_EXIST);
       }
 
-      delete result.userId;
-
       return sucResponse(baseResponse.SUCCESS, result);
     } catch (error) {
       return errResponse(baseResponse.DB_ERROR);

--- a/src/profiles/service/profiles.service.ts
+++ b/src/profiles/service/profiles.service.ts
@@ -127,7 +127,7 @@ export class ProfilesService {
        */
       let imgDir = '';
       // 1. defaultImage: true -> 기본 이미지로 변경 (기존 이미지 삭제)
-      if (editProfileDto.defaultImage === true) {
+      if (editProfileDto.defaultImage === true || editProfileDto.defaultImage === 'true') {
         // 기존 이미지는 삭제
         const prevImgKey = targetProfile.profileImgUrl.slice(`https://${process.env.AWS_S3_BUCKET_NAME}.s3.amazonaws.com/`.length);
         if (prevImgKey !== process.env.DEFAULT_PROFILE_IMAGE_DIR) {


### PR DESCRIPTION
## 📃 작업 사항
- 프로필 관련 API들이 personaId 대신 personaName을 반환하도록 수정

## TODO
- [ ]  프로필 관련 API들 REST 방식 따르도록 수정
  - [ ]  /profiles/create → [POST] /profiles
  - [ ]  /profiles/delete → [DELETE] /profiles/:profileId
  - [ ]  /profiles/edit/:profileId → [PATCH/PUT] /profiles/:profileId
  - [ ]  URI에 따라 위치 재배치
- [ ] 리팩토링
  - [ ]  하나의 함수가 너무 많은 일을 담당중