### PR TITLE
[refactor, feature] 게시글 둘러보기 리팩토링, 해시태그 검색 기능 추가

### DIFF
--- a/src/feeds/service/feeds.service.ts
+++ b/src/feeds/service/feeds.service.ts
@@ -410,44 +410,43 @@ export class FeedsService {
     return sucResponse(baseResponse.SUCCESS);
   }
 
-  async searchFeedsByHashtag(hashtag: string): Promise<any> {
+  async searchFeedsByHashtag(
+    profileId: number,
+    pageNumber: number,
+    categoryId: number,
+    onlyFollowing: boolean,
+    hashtag: string,
+  ): Promise<any> {
     // 1. 해시태그가 있는지 검색
     const hashTagEntity = await this.hashTagRepository.findByName(hashtag);
     // console.log(hashTagEntity);
     // 해시태그가 없는 경우 (검색 결과 없음)
     if (hashTagEntity.length <= 0) {
       return sucResponse(baseResponse.SUCCESS, {
-        message: '검색 결과가 없습니다',
+        empty: '게시물이 없습니다.',
       });
     }
     // 해시태그가 있는 경우
     const hashTagId = hashTagEntity[0].hashTagId;
     // 2. 해시태그 ID를 통해 게시글 검색
-    // let foundDTO: retrieveFeedsReturnDto;
-    // const feedEntity = await this.feedRepsitory.retrieveFeeds(
-    //   profileId,
-    //   pageNumber,
-    //   categoryId,
-    // );
-    // const feedIdList = [];
-    //
-    // console.log(feedEntity);
-    // if (feedEntity.length == 0) {
-    //   return errResponse(baseResponse.FEED_NOT_FOUND);
-    // }
-    // for (let i = 0; i < feedEntity.length; i++) {
-    //   feedIdList.push(feedEntity[i].feedId);
-    // }
-    // const isLikeEntity = await this.likeRepository.isLike(
-    //   feedIdList,
-    //   profileId,
-    // );
-    // console.log(feedEntity);
-    //
-    // foundDTO = new retrieveFeedsReturnDto(feedEntity, isLikeEntity);
-    //
-    // // console.log(util.inspect(foundDTO, {showHidden: false, depth: null}));
-    // return foundDTO;
+    const rawFeedList = await this.feedRepsitory.retrieveOtherFeedsByHashtag(
+      profileId,
+      pageNumber,
+      categoryId,
+      hashTagId,
+    );
+    console.log(rawFeedList);
+
+    // 원하는 정보들만 가공해서 보여주기
+    const feedListDTO: retrieveFeedListDto = new retrieveFeedListDto(rawFeedList, onlyFollowing);
+    // console.log(feedListDTO);
+
+    if (feedListDTO.feedArray.length <= 0) {
+      return sucResponse(baseResponse.SUCCESS, { empty: '게시물이 없습니다.' });
+    }
+    else {
+      return sucResponse(baseResponse.SUCCESS, feedListDTO.feedArray);
+    }
 
     return undefined;
   }


### PR DESCRIPTION
## 📃 작업 사항
- 게시글 둘러보기 탐색 + 팔로잉 을 하나의 라우팅으로 통합
	- 탐색인지, 팔로잉인지는 fResult 라는 쿼리스트링으로 구분
- 게시글 둘러보기 루트 수정
	- profileId를 쿼리가 아닌, param으로 받도록 수정. 해시태그 검색에도 동일하게 적용
- 해시태그 검색 기능 추가
	- query 라는 쿼리스트링을 통해 검색어 받기(현재는 하나의 검색어만을 염두했지만, 추후 여러 검색어를 받을 수 있도록 확장 가능)
	- 탐색인지, 팔로잉인지는 게시글 둘러보기와 똑같은 구조

## TODO
- 해시태그, 피드 더미데이터 추가
- 검색어 여러개 가능하도록 확장할지 검토
