### PR TITLE
fix: 프로필 생성, 수정 사진 용량 5MB로 증가

### DIFF
--- a/src/profiles/controller/profiles.controller.ts
+++ b/src/profiles/controller/profiles.controller.ts
@@ -89,7 +89,7 @@ export class ProfilesController {
   @UseGuards(JWTAuthGuard)
   @Post('/')
   @UsePipes(ValidationPipe)
-  @UseInterceptors(FileInterceptor('image'))
+  @UseInterceptors(FileInterceptor('image', {limits: {fieldSize: 1024 * 1024 * 5}}))
   createProfile(
     @UploadedFile() image: Express.Multer.File,
     @Body() createProfileDto: CreateProfileDto,
@@ -193,7 +193,7 @@ export class ProfilesController {
   })
   @UseGuards(JWTAuthGuard)
   @Patch('/:profileId')
-  @UseInterceptors(FileInterceptor('image'))
+  @UseInterceptors(FileInterceptor('image', {limits: {fieldSize: 1024 * 1024 * 5}}))
   editProfile(
     @Param('profileId', ParseIntPipe) profileId: number,
     @UploadedFile() image: Express.Multer.File,


### PR DESCRIPTION
## 📃 작업 사항
- 프로필 생성, 수정 이미지 업로드 제한 용량 5MB로 증가 테스트