### PR TITLE
[fix] 좋아요 여부 제대로 반영, 피드 최신순 반환

### DIFF
--- a/src/common/utils/dateFormatter.ts
+++ b/src/common/utils/dateFormatter.ts
@@ -1,5 +1,6 @@
 function dateFormatter(createdAt: Date): string {
   const currentTime = new Date();
+  // console.log(currentTime.getTime(), createdAt.getTime());
   const diffTime = currentTime.getTime() - createdAt.getTime();
 
   if (diffTime / (1000 * 60 * 60 * 24) >= 7) {
@@ -10,7 +11,7 @@ function dateFormatter(createdAt: Date): string {
     return year + '년 ' + month + '월 ' + day + '일';
   } else if (diffTime / (1000 * 60 * 60 * 24) > 1) {
     const currentDate = currentTime.getDate();
-    const createdDate = currentTime.getDate();
+    const createdDate = createdAt.getDate();
     const beforeDay = currentDate - createdDate;
 
     return beforeDay + '일 전';

--- a/src/feeds/controller/feeds.controller.ts
+++ b/src/feeds/controller/feeds.controller.ts
@@ -524,7 +524,6 @@ export class FeedsController {
     // 해시태그 가공 - 추후 여러 검색어일 경우를 위하여.. (띄어쓰기로 여러 해시태그 구분)
     // const hashtagArr = hashtags.trim().split(' ');
 
-    
     if (!isFollowing || isFollowing == undefined) {
       isFollowing = false;
     }

--- a/src/feeds/dto/retrieve-feedList.dto.ts
+++ b/src/feeds/dto/retrieve-feedList.dto.ts
@@ -1,96 +1,108 @@
 import { ApiProperty } from '@nestjs/swagger';
-import { create } from 'domain';
-import { FeedImgs } from '../../common/entities/FeedImgs';
-import { Feeds } from '../../common/entities/Feeds';
-import { Likes } from '../../common/entities/Likes';
+import DateFormatter from '../../common/utils/dateFormatter';
 
 export class retrieveFeedListDto {
   @ApiProperty({ description: 'feedArray' })
   feedArray: Feed[] = [];
 
-  constructor(rawFeedList: any[], onlyFollowing: any) {
-    let cnt = 0;
+  constructor(profileId: number, rawFeedList: any[], onlyFollowing: any) {
+    // let cnt = 0;
     // 데이터 가공하기
     for (let i = 0; i < rawFeedList.length; i++) {
-    
       // 탐색 게시글 목록
-      if (onlyFollowing=="false" || onlyFollowing == false) {
-        console.log("not only following");
-        this.feedArray.push(new Feed(rawFeedList.at(i)));
+      if (onlyFollowing == 'false' || onlyFollowing == false) {
+        // console.log('not only following');
+        this.feedArray.push(new Feed(profileId, rawFeedList.at(i)));
       }
       // 팔로잉 게시글 목록
       else {
-        console.log("only following");
+        // console.log('only following');
         if (rawFeedList.at(i).followInfo != null) {
-          this.feedArray.push(new Feed(rawFeedList.at(i)));
+          this.feedArray.push(new Feed(profileId, rawFeedList.at(i)));
         }
       }
-      cnt++;
+      // cnt++;
     }
   }
 }
 
 export class Feed {
-  @ApiProperty()
+  @ApiProperty({
+    description: '게시글 id',
+  })
   private feedId: number;
-  @ApiProperty()
-  private personaId: number;
-  @ApiProperty()
-  private personaName: string;
   @ApiProperty({
     description: '게시글 주인의 프로필 id',
   })
   private profileId: number;
-  @ApiProperty()
+  @ApiProperty({
+    description: '게시글 주인의 프로필 이름',
+  })
   private profileName: string;
-  @ApiProperty()
+  @ApiProperty({
+    description: '게시글 주인의 프로필 사진',
+  })
   private profileImg: string;
-
-  @ApiProperty()
+  // @ApiProperty()
+  // private personaId: number;
+  @ApiProperty({
+    description: '게시글 주인의 페르소나 이름',
+  })
+  private personaName: string;
+  @ApiProperty({
+    description: '게시글이 생성된 시간',
+  })
   private createdAt: string; // 언제 생성된 게시글인지 확인해줘야한다.
-  @ApiProperty()
+  @ApiProperty({
+    description: '게시글 내용',
+  })
   private feedContent: string;
   @ApiProperty({
     description:
-      '피드 이미지의 경우 최대 5개까지 보내집니다. 이미지없이 단순 줄글인경우 빈 배열이 전송됩니다.',
+      '피드 이미지의 경우 최대 5개까지 보내집니다. 이미지 없이 단순 줄글인 경우 빈 배열이 전송됩니다.',
   })
   private feedImgList: Array<string> = [];
   @ApiProperty({
     description:
-      '현재 로그인한 profileId가 이 게시글을 좋아요 눌렀을 경우 true 좋아요를 누르지 않았을 경우 false가 전송됩니다.',
+      '현재 로그인한 profileId가 이 게시글을 좋아요 눌렀을 경우 true, 좋아요를 누르지 않았을 경우 false가 전송됩니다.',
   })
   private isLike: boolean = false;
   @ApiProperty({
     description:
-      '현재 로그인한 profileId가 이 프로필을 팔로우 했을 경우 true 팔로우 하지 않았을 경우 false가 전송됩니다.',
+      '현재 로그인한 profileId가 이 프로필을 팔로우 했을 경우 true, 팔로우 하지 않았을 경우 false가 전송됩니다.',
   })
   private isFollowing: boolean = false;
 
-  @ApiProperty()
-    private hashTagList:Array<String>=new Array();
+  @ApiProperty({
+    description: '게시글에 추가된 해시태그 목록',
+  })
+  private hashTagList: Array<string> = [];
 
-  
-  constructor(feedEntity: any) {
+  constructor(profileId: number, feedEntity: any) {
     this.feedId = feedEntity.feedId;
-    this.personaId = feedEntity.profile.personaId;
-    this.personaName = feedEntity.profile.profileName;
     this.profileId = feedEntity.profileId;
+    this.profileName = feedEntity.profile.profileName;
     this.profileImg = feedEntity.profile.profileImgUrl;
-    this.profileName = feedEntity.profile.persona.personaName;
+    // this.personaId = feedEntity.profile.personaId;
+    this.personaName = feedEntity.profile.persona.personaName;
     this.feedContent = feedEntity.content;
     this.createdAt = this.transformFromDateToFormat(feedEntity.createdAt);
+    // 게시글 사진 목록
     for (let i = 0; i < feedEntity.feedImgs.length; i++) {
       this.feedImgList.push(feedEntity.feedImgs.at(i).feedImgUrl);
     }
-    console.log(feedEntity.feedHashTagMappings.at(0));
+    // 게시글 해시태그 목록
+    // console.log(feedEntity.feedHashTagMappings.at(0));
     if (feedEntity.feedHashTagMappings) {
-      for(let i=0; i<feedEntity.feedHashTagMappings.length;i++){
-        this.hashTagList.push(feedEntity.feedHashTagMappings.at(i).hashTag.hashTagName);
-      }  
+      for (let i = 0; i < feedEntity.feedHashTagMappings.length; i++) {
+        this.hashTagList.push(
+          feedEntity.feedHashTagMappings.at(i).hashTag.hashTagName,
+        );
+      }
     }
     // 좋아요 표시
     // this.isLike = isLike;
-    if (feedEntity.likes.length > 0) {
+    if (feedEntity.likeInfo != null) {
       this.isLike = true;
     }
     // 팔로우 표시
@@ -101,58 +113,37 @@ export class Feed {
   }
 
   transformFromDateToFormat(createdAt: Date) {
-    const currentTime = new Date();
-    const diffTime = currentTime.getTime() - createdAt.getTime();
-    console.log(currentTime);
-    console.log(
-      currentTime.getFullYear() +
-        '년 ' +
-        (currentTime.getMonth() + 1) +
-        '월 ' +
-        currentTime.getDate() +
-        '일 ' +
-        currentTime.getHours() +
-        ':' +
-        currentTime.getMinutes() +
-        ':' +
-        currentTime.getSeconds(),
-    );
-    console.log(createdAt);
-    console.log(
-      createdAt.getFullYear() +
-        '년 ' +
-        (createdAt.getMonth() + 1) +
-        '월 ' +
-        createdAt.getDate() +
-        '일 ' +
-        createdAt.getHours() +
-        ':' +
-        createdAt.getMinutes() +
-        ':' +
-        createdAt.getSeconds(),
-    );
-    if (diffTime / (1000 * 60 * 60 * 24) >= 7) {
-      const year = createdAt.getFullYear();
-      const month = createdAt.getMonth() + 1;
-      const day = createdAt.getDate();
-      // console.log(year+"년 "+month+"월 "+day+"일")
-      return year + '년 ' + month + '월 ' + day + '일';
-    } else if (diffTime / (1000 * 60 * 60 * 24) > 1) {
-      const currentDate = currentTime.getDate();
-      const createdDate = currentTime.getDate();
-      const beforeDay = currentDate - createdDate;
-      return beforeDay + '일 전';
-    } else if (diffTime / (1000 * 60 * 60) > 1) {
-      const beforeHour = diffTime / (1000 * 60 * 60);
-      // console.log(Math.floor(beforeHour)+"시간 전");
-      return Math.round(beforeHour) + '시간 전';
-    } else if (diffTime / (1000 * 60) > 1) {
-      const beforeMinute = diffTime / (1000 * 60);
-      // console.log(Math.floor(beforeMinute)+"분 전");
-      return Math.floor(beforeMinute) + '분 전';
-    } else {
-      // console.log("방금");
-      return '방금';
-    }
+    return DateFormatter(createdAt);
+
+    // const currentTime = new Date();
+    // const diffTime = currentTime.getTime() - createdAt.getTime();
+    // // console.log(currentTime);
+    // // console.log(
+    // //   currentTime.getFullYear() +
+    // //     '년 ' +
+    // //     (currentTime.getMonth() + 1) +
+    // //     '월 ' +
+    // //     currentTime.getDate() +
+    // //     '일 ' +
+    // //     currentTime.getHours() +
+    // //     ':' +
+    // //     currentTime.getMinutes() +
+    // //     ':' +
+    // //     currentTime.getSeconds(),
+    // // );
+    // // console.log(createdAt);
+    // // console.log(
+    // //   createdAt.getFullYear() +
+    // //     '년 ' +
+    // //     (createdAt.getMonth() + 1) +
+    // //     '월 ' +
+    // //     createdAt.getDate() +
+    // //     '일 ' +
+    // //     createdAt.getHours() +
+    // //     ':' +
+    // //     createdAt.getMinutes() +
+    // //     ':' +
+    // //     createdAt.getSeconds(),
+    // // );
   }
 }

--- a/src/feeds/feeds.repository.ts
+++ b/src/feeds/feeds.repository.ts
@@ -121,28 +121,41 @@ export class FeedRepository {
       .leftJoinAndSelect('profiles.persona', 'persona')
       .leftJoinAndSelect('Feeds.feedImgs', 'feedImg')
       .leftJoinAndSelect('Feeds.categories', 'category')
-      .leftJoinAndSelect('Feeds.likes', 'likes')
+      // .leftJoinAndSelect('Feeds.likes', 'likes')
       .leftJoinAndSelect('Feeds.feedHashTagMappings', 'feedHashTagMapping')
-      .leftJoinAndSelect('feedHashTagMapping.hashTag', 'hashTag');
-      
-    if(onlyFollowing=="false" || onlyFollowing==false){
+      .leftJoinAndSelect('feedHashTagMapping.hashTag', 'hashTag')
+      .orderBy({ 'Feeds.createdAt': 'DESC', 'Feeds.feedId': 'DESC' })
+    // .andWhere('likes.profileId=:ownProfileId', { ownProfileId: profileId })   // 본인이 좋아요 누른 게시글만
+    ;
+
+    // 좋아요 여부
+    foundQuery.leftJoinAndMapOne(
+      'Feeds.likeInfo',
+      Likes,
+      'likes',
+      'likes.profileId = :profileId and Feeds.feedId = likes.feedId',
+      { profileId: profileId },
+    );
+
+    // 팔로우 여부
+    if (onlyFollowing == 'false' || onlyFollowing == false) {
       foundQuery.leftJoinAndMapOne(
-            'Feeds.followInfo',
-            FollowFromTo,
-            'followFromTo',
-            'followFromTo.fromUserId = :profileId and followFromTo.toUserId = profiles.profileId',
-            { profileId: profileId },
-        )
-    }else{
+        'Feeds.followInfo',
+        FollowFromTo,
+        'followFromTo',
+        'followFromTo.fromUserId = :profileId and followFromTo.toUserId = profiles.profileId',
+        { profileId: profileId },
+      );
+    } else {
       foundQuery.innerJoinAndMapOne(
         'Feeds.followInfo',
         FollowFromTo,
         'followFromTo',
         'followFromTo.fromUserId = :profileId and followFromTo.toUserId = profiles.profileId',
         { profileId: profileId },
-      )
+      );
     }
-    // .andWhere('likes.profileId=:ownProfileId', { ownProfileId: profileId })   // 본인이 좋아요 누른 게시글만
+
     if (categoryId != 0) {
       //0이 아닐때는 categoryId를 통한 필터링
       foundQuery
@@ -236,7 +249,7 @@ export class FeedRepository {
     pageNumber: number,
     categoryId: number,
     hashTagId: number,
-    onlyFollowing:any,
+    onlyFollowing: any,
   ) {
     const foundQuery = this.feedTable
       .createQueryBuilder('Feeds')
@@ -247,27 +260,37 @@ export class FeedRepository {
       .leftJoinAndSelect('profiles.persona', 'persona')
       .leftJoinAndSelect('Feeds.feedImgs', 'feedImg')
       .leftJoinAndSelect('Feeds.categories', 'category')
-      .leftJoinAndSelect('Feeds.likes', 'likes')
+      // .leftJoinAndSelect('Feeds.likes', 'likes')
       .leftJoinAndSelect('Feeds.feedHashTagMappings', 'feedHashTagMapping')
-      .leftJoinAndSelect('feedHashTagMapping.hashTag','hashTag')
+      .leftJoinAndSelect('feedHashTagMapping.hashTag', 'hashTag')
       .andWhere('feedHashTagMapping.hashTagId=:hashTagId', { hashTagId: hashTagId })
+      .orderBy({ 'Feeds.createdAt': 'DESC', 'Feeds.feedId': 'DESC' })
     ;
-    if(onlyFollowing=="false" || onlyFollowing==false){
+    // 좋아요 여부
+    foundQuery.leftJoinAndMapOne(
+      'Feeds.likeInfo',
+      Likes,
+      'likes',
+      'likes.profileId = :profileId and Feeds.feedId = likes.feedId',
+      { profileId: profileId },
+    );
+    // 팔로우 여부
+    if (onlyFollowing == 'false' || onlyFollowing == false) {
       foundQuery.leftJoinAndMapOne(
-            'Feeds.followInfo',
-            FollowFromTo,
-            'followFromTo',
-            'followFromTo.fromUserId = :profileId and followFromTo.toUserId = profiles.profileId',
-            { profileId: profileId },
-        )
-    }else{
+        'Feeds.followInfo',
+        FollowFromTo,
+        'followFromTo',
+        'followFromTo.fromUserId = :profileId and followFromTo.toUserId = profiles.profileId',
+        { profileId: profileId },
+      );
+    } else {
       foundQuery.innerJoinAndMapOne(
         'Feeds.followInfo',
         FollowFromTo,
         'followFromTo',
         'followFromTo.fromUserId = :profileId and followFromTo.toUserId = profiles.profileId',
         { profileId: profileId },
-      )
+      );
     }
 
     if (categoryId != 0) {

--- a/src/feeds/service/feeds.service.ts
+++ b/src/feeds/service/feeds.service.ts
@@ -29,7 +29,6 @@ const util = require('util');
 
 @Injectable()
 export class FeedsService {
-  
   constructor(
     private feedRepsitory: FeedRepository,
     private likeRepository: LikesRepository,
@@ -41,27 +40,35 @@ export class FeedsService {
     private readonly AwsService: AwsService,
   ) {}
 
-  async getFeedById(feedId: number,profileId:number) {
-    try{
-      const feedEntity:Feeds=await this.feedRepsitory.findFeedById(feedId,profileId);
-      if(!feedEntity){
+  async getFeedById(feedId: number, profileId: number) {
+    try {
+      const feedEntity: Feeds = await this.feedRepsitory.findFeedById(
+        feedId,
+        profileId,
+      );
+      if (!feedEntity) {
         return errResponse(baseResponse.FEED_NOT_FOUND);
       }
-      const isLikeQueryResult=await this.likeRepository.isLike([feedId],profileId);
-      let isLike=false;
-  
-      if(isLikeQueryResult.length>0){
-        isLike=true;
-      }else if(isLikeQueryResult.length==0){
-        isLike=false;
+      const isLikeQueryResult = await this.likeRepository.isLike(
+        [feedId],
+        profileId,
+      );
+      let isLike = false;
+
+      if (isLikeQueryResult.length > 0) {
+        isLike = true;
+      } else if (isLikeQueryResult.length == 0) {
+        isLike = false;
       }
-      
-      const getFeedByIdResDTO:GetFeedByIdResDTO=new GetFeedByIdResDTO(feedEntity,isLike);//isLike처리해야함.
+
+      const getFeedByIdResDTO: GetFeedByIdResDTO = new GetFeedByIdResDTO(
+        feedEntity,
+        isLike,
+      ); //isLike처리해야함.
       return getFeedByIdResDTO;
-    }catch(err){
+    } catch (err) {
       return errResponse(baseResponse.DB_ERROR);
     }
-    
   }
   async patchFeed(patchFeedRequestDTO: PatchFeedRequestDTO) {
     // feedId를 통해 feedEntity가져옴. + save로 수정함.
@@ -243,18 +250,21 @@ export class FeedsService {
       profileId,
       pageNumber,
       categoryId,
-      onlyFollowing
+      onlyFollowing,
     );
     // console.log(rawFeedList);
 
     // 원하는 정보들만 가공해서 보여주기
-    const feedListDTO: retrieveFeedListDto = new retrieveFeedListDto(rawFeedList, onlyFollowing);
+    const feedListDTO: retrieveFeedListDto = new retrieveFeedListDto(
+      profileId,
+      rawFeedList,
+      onlyFollowing,
+    );
     // console.log(feedListDTO);
 
     if (feedListDTO.feedArray.length <= 0) {
-      return sucResponse(baseResponse.SUCCESS, { empty: '게시물이 없습니다.' });
-    }
-    else {
+      return sucResponse(baseResponse.SUCCESS, []);
+    } else {
       return sucResponse(baseResponse.SUCCESS, feedListDTO.feedArray);
     }
   }
@@ -267,55 +277,56 @@ export class FeedsService {
     pageNumber: number,
   ) {
     let feedEntity: Feeds[];
-    try{
-      feedEntity= await this.feedRepsitory.retrieveMyFeedByMonth(
+    try {
+      feedEntity = await this.feedRepsitory.retrieveMyFeedByMonth(
         profileId,
         year,
         month,
         day,
         pageNumber,
       );
-    }catch(err){
+    } catch (err) {
       return errResponse(baseResponse.DB_ERROR);
     }
-    
-    try{
-      const foundDTO: RetreiveMyFeedByMonthReturnDTO =new RetreiveMyFeedByMonthReturnDTO(feedEntity);
 
-      return sucResponse(baseResponse.SUCCESS,foundDTO);
-    }catch(err){
+    try {
+      const foundDTO: RetreiveMyFeedByMonthReturnDTO =
+        new RetreiveMyFeedByMonthReturnDTO(feedEntity);
+
+      return sucResponse(baseResponse.SUCCESS, foundDTO);
+    } catch (err) {
       return errResponse(baseResponse.SERVER_ERROR);
     }
   }
 
-  async RetriveMyFeedInCalender(
-    profileId,
-    year,
-    month,
-  ) {
-    try{
-      const feedEntities: RetreiveMyFeedInCalendarReturnDTO[] = await this.feedRepsitory.RetriveMyFeedInCalender(profileId, year, month);
+  async RetriveMyFeedInCalender(profileId, year, month) {
+    try {
+      const feedEntities: RetreiveMyFeedInCalendarReturnDTO[] =
+        await this.feedRepsitory.RetriveMyFeedInCalender(
+          profileId,
+          year,
+          month,
+        );
       // RetriveMyFeedByMonth와는 다르게 GROUP BY 를 통해 일자별로 정리되어야하며 일자에 따라 ORDER BY 되어야한다.
       console.log('return object');
       // const foundDTOList:RetreiveMyFeedInCalendarReturnDTO[]=[];
-  
+
       // for(let i =0; i<feedEntities.length; i++){
-  
+
       //     console.log(feedEntities[i].feedId);
       //     console.log(feedEntities[i].day);
       //     console.log(feedEntities[i].feedImgUrl);
       //     foundDTOList.push(new RetreiveMyFeedInCalendarReturnDTO(feedEntities[0]));
       // }
-  
+
       // console.log(foundDTOList);
       // const foundDTO:RetreiveMyFeedByMonthReturnDTO=new RetreiveMyFeedByMonthReturnDTO(feedEntity);
       // console.log(foundDTO);
-  
-      return sucResponse(baseResponse.SUCCESS,feedEntities);
-    }catch(err){
+
+      return sucResponse(baseResponse.SUCCESS, feedEntities);
+    } catch (err) {
       return errResponse(baseResponse.DB_ERROR);
     }
-    
   }
 
   async reportFeeds(feedId: number) {
@@ -453,18 +464,21 @@ export class FeedsService {
       pageNumber,
       categoryId,
       hashTagId,
-      onlyFollowing
+      onlyFollowing,
     );
-    console.log(rawFeedList);
+    // console.log(rawFeedList);
 
     // 원하는 정보들만 가공해서 보여주기
-    const feedListDTO: retrieveFeedListDto = new retrieveFeedListDto(rawFeedList, onlyFollowing);
-    console.log(feedListDTO);
+    const feedListDTO: retrieveFeedListDto = new retrieveFeedListDto(
+      profileId,
+      rawFeedList,
+      onlyFollowing,
+    );
+    // console.log(feedListDTO);
 
     if (feedListDTO.feedArray.length <= 0) {
-      return sucResponse(baseResponse.SUCCESS, { empty: '게시물이 없습니다.' });
-    }
-    else {
+      return sucResponse(baseResponse.SUCCESS, []);
+    } else {
       return sucResponse(baseResponse.SUCCESS, feedListDTO.feedArray);
     }
 


### PR DESCRIPTION
<한 일>
- 좋아요 여부 반영
	- feed repository에서 좋아요 처리를 팔로우 처리와 같은 방식으로 처리
	- 해시태그 검색에도 동일하게 적용
- 피드 최신순 반환
	- 시간 변환 'OO일 전' 오류 수정
	- 피드를 기존 feedId 순이 아닌, 가장 최신 순으로 반환하도록 수정

## 📢 관련 이슈
- [x] #번호 

## 📃 작업 사항
- 작업 사항