### PR TITLE
Refactor/logout

### DIFF
--- a/src/auth/auth.controller.ts
+++ b/src/auth/auth.controller.ts
@@ -413,90 +413,6 @@ export class AuthController {
     return getKakaoUser;
   }
 
-  // API No. 4.1.1.2. 카카오 로그인 - 로그아웃
-  @ApiOperation({
-    summary: '4.1.1.2. 카카오 로그인 - 로그아웃',
-    description: `카카오 계정을 통해 로그아웃 한다. (추후 테스트와 보완이 필요함) \n
-        로그아웃 시, 다음 2가지를 처리합니다.\n
-        1. kakao access token 말소 (이후에 카카오 액세스 토큰을 다시 발급 받아야 로그인 가능합니다.)
-        2. 서비스 jwt 제거 (헤더에 담아 보내던 서비스 jwt를 클라이언트에서 지우기/초기화 해야 합니다.)`,
-  })
-  @ApiBearerAuth('Authorization')
-  @ApiBody({
-    required: true,
-    description: '클라이언트에서 받은 카카오 액세스 토큰',
-    schema: { example: { access_token: 'ajdskfj...' } },
-  })
-  @ApiResponse({
-    status: 100,
-    description: 'SUCCESS',
-    schema: {
-      example: sucResponse(baseResponse.SUCCESS, {
-        TODO: '클라이언트에서 jwt를 지워주세요',
-      }),
-    },
-  })
-  @ApiResponse({
-    status: 400,
-    description: 'Body 오류',
-    schema: { example: baseResponse.PIPE_ERROR_EXAMPLE },
-  })
-  @ApiResponse({
-    status: 401,
-    description: 'JWT 오류',
-    schema: { example: errResponse(baseResponse.JWT_UNAUTHORIZED) },
-  })
-  @ApiResponse({
-    status: 500,
-    description: '서버 오류',
-    schema: { example: errResponse(baseResponse.SERVER_ERROR) },
-  })
-  @ApiResponse({
-    status: 1012,
-    description:
-      '카카오 액세서 토큰을 받아오는데 실패함. (인가 코드가 잘못되었거나 유효하지 않음.)',
-    schema: { example: errResponse(baseResponse.KAKAO_ACCESS_TOKEN_FAIL) },
-  })
-  @ApiResponse({
-    status: 1013,
-    description: '카카오 인증 토큰을 request에서 넘겨주지 않음',
-    schema: { example: errResponse(baseResponse.KAKAO_ACCESS_TOKEN_EMPTY) },
-  })
-  @ApiResponse({
-    status: 1014,
-    description:
-      '카카오 유저 정보를 불러오는데 실패함. (액세스 토큰이 잘못되었거나 유효하지 않음.)',
-    schema: { example: errResponse(baseResponse.KAKAO_USER_INFO_FAIL) },
-  })
-  @Post('/kakao-logout')
-  @UseGuards(JWTAuthGuard)
-  async kakaoLogout(
-    @Body('access_token') acces_token: any,
-    @Req() req: Request,
-    @Res() res: Response,
-  ): Promise<any> {
-    if (!acces_token) {
-      return res.send(errResponse(baseResponse.KAKAO_ACCESS_TOKEN_EMPTY));
-    }
-
-    const user: any = req.user;
-    const userId: number = user.userId;
-
-    // 카카오 액세스 토큰으로 카카오 로그아웃 호출하기
-    const kakaoResult = await this.kakaoService.kakaoLogout(
-      userId,
-      acces_token,
-    );
-
-    // 쿠키 지우기 - DEPRECATED
-    // res.cookie('jwt', '', {
-    //   maxAge: 0,
-    // });
-    // ---
-
-    return res.send(kakaoResult);
-  }
-
   // API No. 4.1.2.1. 구글 로그인 - 회원가입/로그인
   @ApiOperation({
     summary: '4.1.2.1. 구글 로그인 - 회원가입/로그인',
@@ -711,7 +627,7 @@ export class AuthController {
   @ApiOperation({
     summary: '1.8.6. 로그아웃',
     description: `헤더에 jwt 정보를 함께 보내 로그아웃 한다. \n
-      로그아웃은 로그인 경로에 상관없이, 알아서 로그아웃 처리를 해줍니다.
+      로그아웃은 로그인 경로에 상관없이, 해당 로그인 타입에 맞게 알아서 로그아웃 처리를 해줍니다.
       로그아웃 성공 이후, 헤더에 보내던 jwt 정보를 클라이언트에서 지워주세요`,
   })
   @ApiBearerAuth('Authorization')

--- a/src/auth/auth.controller.ts
+++ b/src/auth/auth.controller.ts
@@ -250,55 +250,6 @@ export class AuthController {
   // }
   // ---
 
-  // API No. 4.1.4.3. 자체로그인 - 로그아웃 (쿠키의 jwt 값 삭제, 유효기간: 0 으로 변경)
-  @ApiOperation({
-    summary: '4.1.4.3. 자체 로그인 - 로그아웃',
-    description: `헤더에 jwt 정보를 함께 보내 로그아웃 한다. \n
-      로그아웃 성공 이후, 헤더에 보내던 jwt 정보를 클라이언트에서 지워주세요`,
-  })
-  @ApiBearerAuth('Authorization')
-  @ApiResponse({
-    status: 100,
-    description: 'SUCCESS',
-    schema: {
-      example: sucResponse(baseResponse.SUCCESS, {
-        TODO: '클라이언트에서 jwt를 지워주세요',
-      }),
-    },
-  })
-  @ApiResponse({
-    status: 400,
-    description: 'Body 오류',
-    schema: { example: baseResponse.PIPE_ERROR_EXAMPLE },
-  })
-  @ApiResponse({
-    status: 401,
-    description: 'JWT 오류',
-    schema: { example: errResponse(baseResponse.JWT_UNAUTHORIZED) },
-  })
-  @ApiResponse({
-    status: 500,
-    description: '서버 오류',
-    schema: { example: errResponse(baseResponse.SERVER_ERROR) },
-  })
-  @UseGuards(JWTAuthGuard)
-  @Post('/logout')
-  logout(@Res() res: Response): any {
-    // [쿠키를 지우는 방법] - DEPRECATED
-    // res.cookie('jwt', '', {
-    //   maxAge: 0,
-    // });
-    // ---
-
-    // TODO: 자체로그인, 소셜로그인 구분하여 소셜로그인의 경우 소셜계정 연결까지 끊기
-
-    return res.send(
-      sucResponse(baseResponse.SUCCESS, {
-        TODO: '클라이언트에서 jwt를 지워주세요',
-      }),
-    );
-  }
-
   // API No. 4.1.1.1. 카카오 로그인 - 회원가입/로그인
   @ApiOperation({
     summary: '4.1.1.1. 카카오 로그인 - 회원가입/로그인',
@@ -752,6 +703,95 @@ export class AuthController {
         state: appleResult.message,
         jwt: appleResult.serviceJwt,
         // userId: appleResult.socialUserId,
+      }),
+    );
+  }
+
+  // API No. 1.8.6. 로그아웃 (쿠키의 jwt 값 삭제, 유효기간: 0 으로 변경)
+  @ApiOperation({
+    summary: '1.8.6. 로그아웃',
+    description: `헤더에 jwt 정보를 함께 보내 로그아웃 한다. \n
+      로그아웃은 로그인 경로에 상관없이, 알아서 로그아웃 처리를 해줍니다.
+      로그아웃 성공 이후, 헤더에 보내던 jwt 정보를 클라이언트에서 지워주세요`,
+  })
+  @ApiBearerAuth('Authorization')
+  @ApiResponse({
+    status: 100,
+    description: 'SUCCESS',
+    schema: {
+      example: sucResponse(baseResponse.SUCCESS, {
+        TODO: '클라이언트에서 jwt를 지워주세요',
+      }),
+    },
+  })
+  @ApiResponse({
+    status: 400,
+    description: 'Body 오류',
+    schema: { example: baseResponse.PIPE_ERROR_EXAMPLE },
+  })
+  @ApiResponse({
+    status: 401,
+    description: 'JWT 오류',
+    schema: { example: errResponse(baseResponse.JWT_UNAUTHORIZED) },
+  })
+  @ApiResponse({
+    status: 500,
+    description: '서버 오류',
+    schema: { example: errResponse(baseResponse.SERVER_ERROR) },
+  })
+  @ApiResponse({
+    status: 1104,
+    description: '로그아웃 실패 (로그 확인 필요)',
+    schema: { example: errResponse(baseResponse.USER_LOGOUT_FAILED) },
+  })
+  @UseGuards(JWTAuthGuard)
+  @Post('/logout')
+  async logout(@Req() req: Request, @Res() res: Response): Promise<any> {
+    // [쿠키를 지우는 방법] - DEPRECATED
+    // res.cookie('jwt', '', {
+    //   maxAge: 0,
+    // });
+    // ---
+
+    const user: any = req.user;
+    // if (!user || !user.userId) {
+    //   return errResponse(baseResponse.USER_AUTH_WRONG);
+    // }
+    const userId = user.userId;
+    // console.log(userId);
+
+    const loginTypeInfo = await this.authService.identifyLoginTypeInfo(userId);
+    // console.log(loginTypeInfo);
+    if (!loginTypeInfo || loginTypeInfo == undefined) {
+      return res.send(errResponse(baseResponse.USER_LOGOUT_FAILED));
+    }
+
+    // TODO: 소셜 로그인의 경우, 소셜 계정 로그아웃까지 진행
+    const logoutType = loginTypeInfo.login_type;
+    let logoutResult;
+    // 카카오
+    // if (logoutType == 'kakao') {
+    //   const acces_token = logoutType.access_token;
+    //   logoutResult = await this.kakaoService.kakaoLogout(userId, acces_token);
+    // }
+    // // 구글
+    // else if (logoutType == 'google') {
+    //   const id_token = logoutType.provider_token;
+    //   logoutResult = await this.googleService.googleLogout(userId, id_token);
+    // }
+    // // 애플
+    // else if (logoutType == 'apple') {
+    //   const identity_token = logoutType.provider_token;
+    //   logoutResult = await this.appleService.appleLogout(userId, identity_token);
+    // }
+    // console.log(logoutResult);
+
+    // 토큰 정보 초기화
+    const resetTokenResult = await this.authService.resetTokens(userId);
+
+    return res.send(
+      sucResponse(baseResponse.SUCCESS, {
+        TODO: '클라이언트에서 jwt를 지워주세요',
       }),
     );
   }

--- a/src/auth/auth.service.ts
+++ b/src/auth/auth.service.ts
@@ -129,4 +129,12 @@ export class AuthService {
   async resetTokens(userId: number): Promise<any> {
     return await this.userService.deleteTokens(userId);
   }
+
+  async identifyLoginTypeInfo(userId: number): Promise<any> {
+    // 어느 경로로 로그인한 사용자인가 - login_type, access_token, provider_token 정보
+    const loginTypeUserInfo = await this.userService.getUserLoginInfo(userId);
+    // console.log(loginTypeUserInfo);
+
+    return loginTypeUserInfo;
+  }
 }

--- a/src/auth/user.service.ts
+++ b/src/auth/user.service.ts
@@ -162,4 +162,14 @@ export class UserService {
       .where('userId = :userId', { userId: userId })
       .execute();
   }
+
+  async getUserLoginInfo(userId: number) {
+    const loginInfo = await this.userRepository
+      .createQueryBuilder('user')
+      .select(['user.login_type, user.access_token, user.provider_token'])
+      .where('user.userId = :id', { id: userId })
+      .getOne();
+
+    return loginInfo;
+  }
 }

--- a/src/common/utils/baseResponseStatus.ts
+++ b/src/common/utils/baseResponseStatus.ts
@@ -47,6 +47,7 @@ const baseResponse = {
   USER_NOT_FOUND: { statusCode: 1101, message: '회원 정보가 없습니다.' },
   WRONG_LOGIN: { statusCode: 1102, message: '다른 플랫폼으로 가입된 회원입니다.' },
   USER_STATUS_ERROR: { statusCode: 1103, message: '요청 Body가 잘못되었습니다.' },
+  USER_LOGOUT_FAILED: { statusCode: 1104, message: '로그아웃에 실패했습니다.' },
 
   // 프로필 관련
   PROFILE_COUNT_OVER: { statusCode: 1500, message: '사용자 프로필은 5개까지 생성 가능합니다.' },


### PR DESCRIPTION
## 📢 관련 이슈
- [x] #7 

## 📃 작업 사항
- 로그아웃 구조 리팩토링
            - 기존 로그인 경로별 로그아웃을 따로 구현하는 방식이 아닌, 하나의 로그아웃 api로 각각에 맞는 로그아웃 기능을 수행하도록 함
            - 소셜 로그인의 경우, 해당 소셜 계정 로그아웃 api를 추가적으로 설정해줘야할 수도 있다
            - 현재는 처리 X, 추후 문제가 되면 추가하는 것으로..

## TODO
- 만약, 소셜 계정 로그아웃 처리를 추가적으로 해결해줘야하면, 대대적인 리팩토링이 필요할수도 있음